### PR TITLE
Use ``` code format in binary-exp

### DIFF
--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -39,52 +39,52 @@ and it is still used inside CPUs of contemporary computers!
 The approach described above could be easily implemented with a single loop.
 
 **Non-recursive** approach in Python 3 <span class="toggle-code">Show/Hide</span>:
-
-    def binpow(a, b):
-	    res = 1
-	    cur = a
-	    while b > 0:
-		    if b & 1:
-			    res *= cur
-		    cur *= cur
-		    b >>= 1
-	    return res
-
+```python
+def binpow(a, b):
+    res = 1
+    cur = a
+    while b > 0:
+	    if b & 1:
+		    res *= cur
+	    cur *= cur
+	    b >>= 1
+    return res
+```
 Approach in C++ <span class="toggle-code">Show/Hide</span>:
-
-	long long binpow(long long a,long long b)
-	{
-		long long res = 1;
-		while (b){
-			if (b & 1) res = res * a;
-			a = (a * a);
-			b >>= 1;
-		}
-		return res;
+```cpp
+long long binpow(long long a,long long b)
+{
+	long long res = 1;
+	while (b){
+		if (b & 1) res = res * a;
+		a = (a * a);
+		b >>= 1;
 	}
-
+	return res;
+}
+```
 This approach builds the result starting from smallest degrees of `a`. If we use recursion
 instead of loop we can work in "inverse" direction, starting from largest degrees and dividing
 `b` in two at each step.
 
 **Recursive** approach in Python 3 <span class="toggle-code">Show/Hide</span>:
-
-    def binpow(a, b):
-	    if b == 1:
-		    return a
-	    res = binpow(a, b // 2)
-	    return res * res * (a if b % 2 != 0 else 1)
-
+```python
+def binpow(a, b):
+    if b == 1:
+	    return a
+    res = binpow(a, b // 2)
+    return res * res * (a if b % 2 != 0 else 1)
+```
 Approach in C++ <span class="toggle-code">Show/Hide</span>:
-
-	long long binpow(long long a,long long b)
-	{
-		if (b == 1) return a;
-		long long res = binpow(a, b/2);
-		if (b % 2) return res*res*a;
-		else return res * res;
-	}
-
+```cpp
+long long binpow(long long a,long long b)
+{
+	if (b == 1) return a;
+	long long res = binpow(a, b/2);
+	if (b % 2) return res*res*a;
+	else return res * res;
+}
+```
 We can explain this last approach mathematically:
 $a^{b} = (a^{b/2})^2 \quad$ for even `b`,
 $a^{b} = (a^{(b-1)/2})^2 \cdot a \quad$ for odd `b`,


### PR DESCRIPTION
Following #117 , use ``` instead of \tab for code format.