### PR TITLE
Test to replace short Latex usage to markdown

### DIFF
--- a/src/geometry/area-of-simple-polygon.md
+++ b/src/geometry/area-of-simple-polygon.md
@@ -25,6 +25,6 @@ double area(const vector<point>& fig) {
 ```
 
 ## Method 2
-We can choose a point $O$ arbitrarily, iterate over all edges adding the oriented area of the triangle formed by the edge and point $O$. Again, due to the sign of area, extra area will be reduced.
+We can choose a point `O` arbitrarily, iterate over all edges adding the oriented area of the triangle formed by the edge and point `O`. Again, due to the sign of area, extra area will be reduced.
 
 This method is better as it can be generalized to more complex cases (such as when some sides are arcs instead of straight lines)

--- a/src/geometry/circle-line-intersection.md
+++ b/src/geometry/circle-line-intersection.md
@@ -8,7 +8,7 @@ Given the coordinates of the center of a circle and it's radius, and the equatio
 
 Instead of solving the system of two equations, we will approach the problem geometrically. This way we get a more accurate solution from the point of view of numerical stability.
 
-We assume without loss of generality that the circle is centered at the origin. If it's not, we translate it there and correct the $C$ constant in the line equation. So we have a circle centered at $(0,0)$ of radius $r$ and a line with equation $Ax+By+C=0$.
+We assume without loss of generality that the circle is centered at the origin. If it's not, we translate it there and correct the `C` constant in the line equation. So we have a circle centered at $(0,0)$ of radius `r` and a line with equation $Ax+By+C=0$.
 
 Let's start by find the point on the line which is closest to the origin $(x_0, y_0)$. First, it has to be at a distance
 
@@ -21,13 +21,13 @@ $$ y_0 = - \frac{BC}{A^2 + B^2} $$
 
 The minus signs are not obvious, but they can be easily verified by substituting $x_0$ and $y_0$ in the equation of the line.
 
-At this stage we can determine the number of intersection points, and even find the solution when there is one or zero points. Indeed, if the distance from $(x_0, y_0)$ to the origin $d_0$ is greater than the radius $r$, the answer is **zero points**. If $d_0=r$, the answer is **one point** $(x_0, y_0)$. If $d_0<r$, there are two points of intersection, and now we have to find their coordinates.
+At this stage we can determine the number of intersection points, and even find the solution when there is one or zero points. Indeed, if the distance from $(x_0, y_0)$ to the origin $d_0$ is greater than the radius `r`, the answer is **zero points**. If $d_0=r$, the answer is **one point** $(x_0, y_0)$. If $d_0<r$, there are two points of intersection, and now we have to find their coordinates.
 
-So, we know that the point $(x_0, y_0)$ is inside the circle. The two points of intersection, $(a_x, a_y)$ and $(b_x, b_y)$, must belong to the line $Ax+By+C=0$ and must be at the same distance $d$ from $(x_0, y_0)$, and this distance is easy to find:
+So, we know that the point $(x_0, y_0)$ is inside the circle. The two points of intersection, $(a_x, a_y)$ and $(b_x, b_y)$, must belong to the line $Ax+By+C=0$ and must be at the same distance `d` from $(x_0, y_0)$, and this distance is easy to find:
 
 $$ d = \sqrt{r^2 - \frac{C^2}{A^2 + B^2}} $$
 
-Note that the vector $(-B, A)$ is collinear to the line, and thus we can find the points in question by adding and subtracting  vector $(-B,A)$, scaled to the length $d$, to the point $(x_0, y_0)$. 
+Note that the vector $(-B, A)$ is collinear to the line, and thus we can find the points in question by adding and subtracting  vector $(-B,A)$, scaled to the length `d`, to the point $(x_0, y_0)$. 
 
 Finally, the equations of the two points of intersection are:
 
@@ -39,7 +39,7 @@ Had we solved the original system of equations using algebraic methods, we would
 
 ## Implementation
 
-As indicated at the outset, we assume that the circle is centered at the origin, and therefore the input to the program is the radius $r$ of the circle and the parameters $A$, $B$ and $C$ of the equation of the line.
+As indicated at the outset, we assume that the circle is centered at the origin, and therefore the input to the program is the radius `r` of the circle and the parameters `A`, `B` and `C` of the equation of the line.
 
 ```cpp
 double r, a, b, c; // given as input

--- a/src/geometry/convex_hull_trick.md
+++ b/src/geometry/convex_hull_trick.md
@@ -2,11 +2,11 @@
 
 # Convex hull trick and Li Chao tree
 
-Consider the following problem. There are $n$ cities. You want to travel from city $1$ to city $n$ by car. To do this you have to buy some gasoline. It is known that a liter of gasoline costs $cost_k$ in the $k^{th}$ city. Initially your fuel tank is empty and you spend one liter of gasoline per kilometer. Cities are located on the same line in ascending order with $k^{th}$ city having coordinate $x_k$. Also you have to pay $toll_k$ to enter $k^{th}$ city. Your task is to make the trip with minimum possible cost. It's obvious that the solution can be calculated via dynamic programming:
+Consider the following problem. There are `n` cities. You want to travel from city `1` to city `n` by car. To do this you have to buy some gasoline. It is known that a liter of gasoline costs $cost_k$ in the $k^{th}$ city. Initially your fuel tank is empty and you spend one liter of gasoline per kilometer. Cities are located on the same line in ascending order with $k^{th}$ city having coordinate $x_k$. Also you have to pay $toll_k$ to enter $k^{th}$ city. Your task is to make the trip with minimum possible cost. It's obvious that the solution can be calculated via dynamic programming:
 
 $$dp_i = toll_i+\min\limits_{j<i}(cost_j \cdot (x_i - x_j)+dp_j)$$
 
-Naive approach will give you $O(n^2)$ complexity which can be improved to $O(n \log n)$ or $O(n \log [C \varepsilon^{-1}])$ where $C$ is largest possible $|x_i|$ and $\varepsilon$ is precision with which $x_i$ is considered ($\varepsilon = 1$ for integers which is usually the case). To do this one should note that the problem can be reduced to adding linear functions $k \cdot x + b$ to the set and finding minimum value of the functions in some particular point $x$. There are two main approaches one can use here.
+Naive approach will give you $O(n^2)$ complexity which can be improved to $O(n \log n)$ or $O(n \log [C \varepsilon^{-1}])$ where `C` is largest possible $|x_i|$ and $\varepsilon$ is precision with which $x_i$ is considered ($\varepsilon = 1$ for integers which is usually the case). To do this one should note that the problem can be reduced to adding linear functions $k \cdot x + b$ to the set and finding minimum value of the functions in some particular point `x`. There are two main approaches one can use here.
 
 ## Convex hull trick
 
@@ -16,7 +16,7 @@ Idea of this approach is to maintain a lower convex hull of linear functions. Ac
 
 One have to keep points in convex hull alongside with normal vectors of edges of convex hull. When you have $(x;1)$ query you'll have to find normal vector closest to it in terms of angles between them, then optimum linear function will correspond to one of its endpoints. To see that one should note that points having same dot product with $(x;1)$ lie on same line which is orthogonal to $(x;1)$ so optimum linear function will be the one in which tangent to convex hull which is collinear with normal to $(x;1)$ touches the hull. This point can be found as one such that normals of edges lying to the left and to the right of it are headed in different sides of $(x;1)$.
 
-This approach is useful when queries of adding linear functions are monotone in terms of $k$ or if we work offline, i.e. we may firstly add all linear functions and answer queries afterwards. So we cannot solve the cities/gasoline problems using this way. That would require handling online queries. When it comes to deal with online queries however, things will go tough and one will have to use some kind of set data structure to implement a proper convex hull. Online approach will however not be considered in this article due to its hardness and because second approach (which is Li Chao tree) allows to solve the problem way simpler. Worth mentioning that one can still use this approach in online without complications by square-root-decomposition. That is, rebuild convex hull from scratch each $\sqrt n$ new lines. 
+This approach is useful when queries of adding linear functions are monotone in terms of `k` or if we work offline, i.e. we may firstly add all linear functions and answer queries afterwards. So we cannot solve the cities/gasoline problems using this way. That would require handling online queries. When it comes to deal with online queries however, things will go tough and one will have to use some kind of set data structure to implement a proper convex hull. Online approach will however not be considered in this article due to its hardness and because second approach (which is Li Chao tree) allows to solve the problem way simpler. Worth mentioning that one can still use this approach in online without complications by square-root-decomposition. That is, rebuild convex hull from scratch each $\sqrt n$ new lines. 
 
 To implement this approach one should begin with some wrap for points class, here we suggest to use C++ complex number type.
 
@@ -35,7 +35,7 @@ ftype cross(point a, point b) {
 }
 ```
 
-Here we will assume that when linear functions are added, their $k$ only increases and we want to find minimum values. We will keep points in vector $hull$ and normal vectors in vector $vecs$. When we add a new point, we have to look at the angle formed between last edge in convex hull and vector from last point in convex hull to new point. This angle have to be directed counter-clockwise, that is the dot product of the last normal vector in the hull (directed inside hull) and the vector from the last point to the new one has to be non-negative. As long as this isn't true, we should erase the last point in the convex hull alongside with the corresponding edge.
+Here we will assume that when linear functions are added, their `k` only increases and we want to find minimum values. We will keep points in vector `hull` and normal vectors in vector `vecs`. When we add a new point, we have to look at the angle formed between last edge in convex hull and vector from last point in convex hull to new point. This angle have to be directed counter-clockwise, that is the dot product of the last normal vector in the hull (directed inside hull) and the vector from the last point to the new one has to be non-negative. As long as this isn't true, we should erase the last point in the convex hull alongside with the corresponding edge.
 
 ```cpp
 vector<point> hull, vecs;
@@ -53,7 +53,7 @@ void add_line(ftype k, ftype b) {
 }
  
 ```
-Now to get the minimum value in some point we will find the first normal vector in the convex hull that is directed counter-clockwise from $(x;1)$. The left endpoint of such edge will be the answer. To check if vector $a$ is directed counter-clockwise of vector $b$ we should check if their cross product $[a,b]$ is negative.
+Now to get the minimum value in some point we will find the first normal vector in the convex hull that is directed counter-clockwise from $(x;1)$. The left endpoint of such edge will be the answer. To check if vector `a` is directed counter-clockwise of vector `b` we should check if their cross product $[a,b]$ is negative.
 ```cpp
 int get(ftype x) {
     point query = {x, 1};
@@ -68,7 +68,7 @@ int get(ftype x) {
 
 Assume you're given a set of functions such that each two can intersect at most once. Let's keep in each vertex of a segment tree some function in such way, that if we go from root to the leaf it will be guaranteed that one of the functions we met on the path will be the one giving the minimum value in that leaf. Let's see how to construct it.
 
-Assume we're in some vertex corresponding to half-segment $[l;r)$ and the function $f_{old}$ is kept there and we add the function $f_{new}$. Then the intersection point will be either in $[l;m)$ or in $[m;r)$ where $m=\left\lfloor\tfrac{l+r}{2}\right\rfloor$. We can efficiently find that out by comparing the values of the functions in points $l$ and $m$. If the dominating function changes, then it is in $[l;m)$ otherwise it is in $[m;r)$. Now for the half of the segment with no intersection we will pick the lower function and write it in the current vertex. You can see that it will always be the one which is lower in point $m$. After that we recursively go to the other half of the segment with the function which was the upper one. As you can see this will keep correctness on the first half of segment and in the other one correctness will be maintained during the recursive call. Thus we can add functions and check the minimum value in the point in $O(\log [C\varepsilon^{-1}])$.
+Assume we're in some vertex corresponding to half-segment $[l;r)$ and the function $f_{old}$ is kept there and we add the function $f_{new}$. Then the intersection point will be either in $[l;m)$ or in $[m;r)$ where $m=\left\lfloor\tfrac{l+r}{2}\right\rfloor$. We can efficiently find that out by comparing the values of the functions in points `l` and `m`. If the dominating function changes, then it is in $[l;m)$ otherwise it is in $[m;r)$. Now for the half of the segment with no intersection we will pick the lower function and write it in the current vertex. You can see that it will always be the one which is lower in point `m`. After that we recursively go to the other half of the segment with the function which was the upper one. As you can see this will keep correctness on the first half of segment and in the other one correctness will be maintained during the recursive call. Thus we can add functions and check the minimum value in the point in $O(\log [C\varepsilon^{-1}])$.
 
 Here is the illustration of what is going on in the vertex when we add new function:
 
@@ -90,7 +90,7 @@ ftype f(point a,  ftype x) {
     return dot(a, {x, 1});
 }
 ```
-We will keep functions in the array $line$ and use binary indexing of the segment tree. If you want to use it on large numbers or doubles, you should use a dynamic segment tree. 
+We will keep functions in the array `line` and use binary indexing of the segment tree. If you want to use it on large numbers or doubles, you should use a dynamic segment tree. 
 ```cpp
 const int maxn = 2e5;
  
@@ -112,7 +112,7 @@ void add_line(point nw, int v = 1, int l = 0, int r = maxn) {
     }
 }
 ```
-Now to get the minimum in some point $x$ we simply choose the minimum value along the path to the point.
+Now to get the minimum in some point `x` we simply choose the minimum value along the path to the point.
 ```cpp
 int get(int x, int v = 1, int l = 0, int r = maxn) {
     int m = (l + r) / 2;

--- a/src/geometry/lattice-points.md
+++ b/src/geometry/lattice-points.md
@@ -30,12 +30,12 @@ Then we should start with summing up points below $y=\lfloor k \rfloor \cdot x +
 $$\sum\limits_{x=0}^{n - 1} \lfloor k \rfloor \cdot x + \lfloor b \rfloor=\dfrac{(\lfloor k \rfloor(n-1)+2\lfloor b \rfloor) n}{2}.$$
 Now we are interested only in points $(x;y)$ such that $\lfloor k \rfloor \cdot x + \lfloor b \rfloor < y \leq k\cdot x + b$.
 This amount is the same as the number of points such that $0 < y \leq (k - \lfloor k \rfloor) \cdot x + (b - \lfloor b \rfloor)$.
-So we reduced our problem to $k'= k - \lfloor k \rfloor$, $b' = b - \lfloor b \rfloor$ and both $k'$ and $b'$ less than $1$ now.
-Here is a picture, we just summed up blue points and subtracted the blue linear function from the black one to reduce problem to smaller values for $k$ and $b$:
+So we reduced our problem to $k'= k - \lfloor k \rfloor$, $b' = b - \lfloor b \rfloor$ and both $k'$ and $b'$ less than `1` now.
+Here is a picture, we just summed up blue points and subtracted the blue linear function from the black one to reduce problem to smaller values for `k` and `b`:
 <center>![Subtracting floored linear function](&imgroot&/lattice.png)</center>
 
 - $k < 1$ and $b < 1$.
-If $\lfloor k \cdot n + b\rfloor$ equals $0$, we can safely return $0$.
+If $\lfloor k \cdot n + b\rfloor$ equals `0`, we can safely return `0`.
 If this is not the case, we can say that there are no lattice points such that $x < 0$ and $0 < y \leq k \cdot x + b$.
 That means that we will have the same answer if we consider new reference system in which $O'=(n;\lfloor k\cdot n + b\rfloor)$, axis $x'$ is directed down and axis $y'$ is directed to the left.
 For this reference system we are interested in lattice points on the set
@@ -49,7 +49,7 @@ As you see, in new reference system linear function will have coefficient $\tfra
 
 We have to count at most $\dfrac{(k(n-1)+2b)n}{2}$ points.
 Among them we will count $\dfrac{\lfloor k \rfloor (n-1)+2\lfloor b \rfloor}{2}$ on the very first step.
-We may consider that $b$ is negligibly small because we can start with making it less than $1$.
+We may consider that `b` is negligibly small because we can start with making it less than `1`.
 In that case we cay say that we count about $\dfrac{\lfloor k \rfloor}{k} \geq \dfrac 1 2$  of all points.
 Thus we will finish in $O(\log n)$ steps.
 
@@ -77,6 +77,6 @@ int count_lattices(Fraction k, Fraction b, long long n) {
 ```
 
 Here `Fraction` is some class handling rational numbers.
-On practice it seems that if all denominators and numerators are at most $C$ by absolute value then in the recursive calls they will be at most $C^2$ if you keep dividing numerators and denominators by their greatest common divisor.
-Given this assumption we can say that one may use doubles and require accuracy of $\varepsilon^2$ where $\varepsilon$ is accuracy with which $k$ and $b$ are given.
+On practice it seems that if all denominators and numerators are at most `C` by absolute value then in the recursive calls they will be at most $C^2$ if you keep dividing numerators and denominators by their greatest common divisor.
+Given this assumption we can say that one may use doubles and require accuracy of $\varepsilon^2$ where $\varepsilon$ is accuracy with which `k` and `b` are given.
 That means that in floor one should consider numbers as integer if they differs at most by $\varepsilon^2$ from an integer.

--- a/src/geometry/length-of-segments-union.md
+++ b/src/geometry/length-of-segments-union.md
@@ -2,13 +2,13 @@
 
 # Length of the union of intervals on a line in $O(n\log n)$
 
-Given $n$ segments on a line, each one by a pair of coordinates $(x_{2i}, x_{2i+1})$, find the length of their union.
+Given `n` segments on a line, each one by a pair of coordinates $(x_{2i}, x_{2i+1})$, find the length of their union.
 
 The following algorithm was proposed by Klee in 1977. It works in $O(n\log n)$ and has been proved to be the asymptotically fastest.
 
 ## Solution
 
-Store in an array $X$ the endpoints of all the segments sorted by its value, with the left end first if their values are equal, and wether it is a left end or a right end of a segment. Now go through the array keeping a counter $C$ of overlapping segments. If $C$ is non-zero, then add $x_i-x_{i-1}$ to the answer; if the current element is a left end we increase this counter, and otherwise we decrease it.
+Store in an array `X` the endpoints of all the segments sorted by its value, with the left end first if their values are equal, and wether it is a left end or a right end of a segment. Now go through the array keeping a counter `C` of overlapping segments. If `C` is non-zero, then add $x_i-x_{i-1}$ to the answer; if the current element is a left end we increase this counter, and otherwise we decrease it.
 
 ## Implementation
 

--- a/src/geometry/lines-intersection.md
+++ b/src/geometry/lines-intersection.md
@@ -16,11 +16,11 @@ Using Cramer's rule, we immediately find the solution for the system, which will
 $$ x = - \frac{ \left|\matrix{C_1&B_1 \cr C_2&B_2}\right| }{ \left|\matrix{A_1&B_1 \cr A_2&B_2}\right| } = - \frac{ C_1 B_2 - C_2 B_1 }{ A_1 B_2 - A_2 B_1 }, $$
 $$ y = - \frac{ \left|\matrix{A_1&C_1 \cr A_2&C_2}\right| }{ \left|\matrix{A_1&B_1 \cr A_2&B_2}\right| } = - \frac{ A_1 C_2 - A_2 C_1 }{ A_1 B_2 - A_2 B_1 }. $$
 
-If the denominator equals $0$, i.e.
+If the denominator equals `0`, i.e.
 
 $$ \left|\matrix{A_1&B_1 \cr A_2&B_2}\right| = A_1 B_2 - A_2 B_1 = 0 $$
 
-then either the system has no solutions (the lines are parallel and distinct) or there are infinitely many solutions (the lines overlap). If we need to distinguish these two cases, we have to check if coefficients $C$ are proportional with the same ratio as the coefficients $A$ and $B$. To do that we only have calculate the following determinants, and if they both equal $0$, the lines overlap:
+then either the system has no solutions (the lines are parallel and distinct) or there are infinitely many solutions (the lines overlap). If we need to distinguish these two cases, we have to check if coefficients `C` are proportional with the same ratio as the coefficients `A` and `B`. To do that we only have calculate the following determinants, and if they both equal `0`, the lines overlap:
 
 $$ \left|\matrix{ A_1 & C_1 \cr A_2 & C_2 }\right|, \left|\matrix{ B_1 & C_1 \cr B_2 & C_2 }\right| $$
 

--- a/src/geometry/picks-theorem.md
+++ b/src/geometry/picks-theorem.md
@@ -8,13 +8,13 @@ A polygon without self-intersections is called lattice if all its vertices have 
 
 Given a certain lattice polygon with non-zero area.
 
-We denote its area by $S$, the number of points with integer coordinates lying strictly inside the polygon by $I$ and the number of points lying on polygon sides by $B$.
+We denote its area by `S`, the number of points with integer coordinates lying strictly inside the polygon by `I` and the number of points lying on polygon sides by `B`.
 
 Then, the **Pick's formula** states:
 
 $$S=I+\frac{B}{2}-1$$
 
-In particular, if the values of $I$ and $B$ for a polygon are given, the area can be calculated in $O(1)$ without even knowing the vertices.
+In particular, if the values of `I` and `B` for a polygon are given, the area can be calculated in $O(1)$ without even knowing the vertices.
 
 This formula was discovered and proven by Austrian mathematician Georg Alexander Pick in 1899.
 
@@ -24,9 +24,9 @@ The proof is carried out in many stages: from simple polygons to arbitrary ones:
 
 - A single square: $S=1, I=0, B=4$, which satisfies the formula.
 
-- An arbitrary non-degenerate rectangle with sides parallel to coordinate axes: Assume $a$ and $b$ be the length of the sides of rectangle. Then, $S=ab, I=(a-1)(b-1), B=2(a+b)$. On substituting, we see that formula is true.
+- An arbitrary non-degenerate rectangle with sides parallel to coordinate axes: Assume `a` and `b` be the length of the sides of rectangle. Then, $S=ab, I=(a-1)(b-1), B=2(a+b)$. On substituting, we see that formula is true.
 
-- A right angle with legs parallel to the axes: To prove this, note that any such triangle can be obtained by cutting off a rectangle by a diagonal. Denoting the number of integral points lying on diagonal by $c$, it can be shown that Pick's formula holds for this triangle regardless of $c$.
+- A right angle with legs parallel to the axes: To prove this, note that any such triangle can be obtained by cutting off a rectangle by a diagonal. Denoting the number of integral points lying on diagonal by `c`, it can be shown that Pick's formula holds for this triangle regardless of `c`.
 
 - An arbitrary triangle: Note that any such triangle can be turned into a rectangle by attaching it to sides of right-angled triangles with legs parallel to the axes (you will not need more than 3 such triangles). From here, we can get correct formula for any triangle.
 
@@ -43,7 +43,7 @@ B=(1,0,0),
 C=(0,1,0),
 D=(1,1,k),$$
 
-where $k$ can be any natural number. Then for any $k$, the tetrahedron $ABCD$ does not contain integer point inside it and has only $4$ points on its borders, $A, B, C, D$. Thus, the volume and surface area may vary in spite of unchanged number of points within and on boundary. Therefore, Pick's theorem doesn't allow generalizations.
+where `k` can be any natural number. Then for any `k`, the tetrahedron `ABCD` does not contain integer point inside it and has only `4` points on its borders, $A, B, C, D$. Thus, the volume and surface area may vary in spite of unchanged number of points within and on boundary. Therefore, Pick's theorem doesn't allow generalizations.
 
 However, higher dimensions still has a generalization using **Ehrhart polynomials** but they are quite complex and depends not only on points inside but also on the boundary of polytype.
 


### PR DESCRIPTION
Here is an issue #120, which proposes to replace usage of Latex for very short fragments (e.g. one letter, digit or short word). I couldn't say how important it is for SEO. Intuitively this makes snippets of text look cleaner. It is surely good in search output (which is not processed with javascript latex).

Visually such fragment will seem different from latex (according to current style of preformatted text). Not sure is it good or bad, but this makes them a bit more easily distinguishable.

There is over 700 places to change, so I decided to start small: I replaced such fragments for now in few articles in "geometry" folder. Please see and tell your opinion - is it worth to proceed.