### PR TITLE
Reduced number of operations in block sieve code

### DIFF
--- a/src/algebra/sieve-of-eratosthenes.md
+++ b/src/algebra/sieve-of-eratosthenes.md
@@ -145,7 +145,7 @@ int count_primes(int n) {
         if (is_prime[i]) {
             primes.push_back(i);
             for (int j = i * i; j <= nsqrt; j += i)
-                is_prime[j] = true;
+                is_prime[j] = false;
         }
     }
 

--- a/src/algebra/sieve-of-eratosthenes.md
+++ b/src/algebra/sieve-of-eratosthenes.md
@@ -156,7 +156,7 @@ int count_primes(int n) {
         int start = k * S;
         for (int p : primes) {
             int start_idx = (start + p - 1) / p;
-            int j = max(start_idx, 2) * p - start;
+            int j = max(start_idx, p) * p - start;
             for (; j < S; j += p)
                 block[j] = false;
         }


### PR DESCRIPTION
Changed max(start_idx, 2) * p to max(start_idx, p) * p. This is done so that we always start from the max. of the smallest multiple of p in the range [l, r] and p * p. It is more beneficial to start from p * p rather than 2 * p as lower multiples of p would have been covered by the smaller prime factors.

