### PR TITLE
Fixed bug in strongly connected components

### DIFF
--- a/src/graph/strongly-connected-components.md
+++ b/src/graph/strongly-connected-components.md
@@ -51,7 +51,7 @@ Finally, it is appropriate to mention [topological sort](./graph/topological-sor
 ## Implementation
 ```cpp
     vector < vector<int> > g, gr;
-    vector<char> used;
+    vector<bool> used;
     vector<int> order, component;
      
     void dfs1 (int v) {


### PR DESCRIPTION
The 'used' vector in the code of SCC should be of type bool, not char