### PR TITLE
Fixes to binexp and Josephus

### DIFF
--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -33,7 +33,7 @@ $$\begin{align}
 3^2 &= \left(3^1\right)^2 = 3^2 = 9 \\\\
 3^4 &= \left(3^2\right)^2 = 9^2 = 81 \\\\
 3^8 &= \left(3^4\right)^2 = 81^2 = 6561
-\end{align}
+\end{align}$$
 
 So to get the final answer for $3^{13}$, we only need to multiply three of them (skipping $3^2$ because the corresponding bit in $n$ is not set):
 $3^{13} = 6561 \cdot 81 \cdot 3 = 1594323$

--- a/src/others/josephus_problem.md
+++ b/src/others/josephus_problem.md
@@ -18,18 +18,19 @@ We will try to find a pattern expressing the answer for the problem $J_{n, k}$ t
 
 Using brute force modeling we can construct a table of values, for example, the following:
 
-$$\begin{matrix} n\setminus k & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10\cr
-1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1\cr
-2 & 2 & 1 & 2 & 1 & 2 & 1 & 2 & 1 & 2 & 1\cr
-3 & 3 & 3 & 2 & 2 & 1 & 1 & 3 & 3 & 2 & 2\cr
-4 & 4 & 1 & 1 & 2 & 2 & 3 & 2 & 3 & 3 & 4\cr
-5 & 5 & 3 & 4 & 1 & 2 & 4 & 4 & 1 & 2 & 4\cr
-6 & 6 & 5 & 1 & 5 & 1 & 4 & 5 & 3 & 5 & 2\cr
-7 & 7 & 7 & 4 & 2 & 6 & 3 & 5 & 4 & 7 & 5\cr
-8 & 8 & 1 & 7 & 6 & 3 & 1 & 4 & 4 & 8 & 7\cr
-9 & 9 & 3 & 1 & 1 & 8 & 7 & 2 & 3 & 8 & 8\cr
-10 & 10 & 5 & 4 & 5 & 3 & 3 & 9 & 1 & 7 & 8\cr
-\end{matrix}$$
+$$\begin{array}{ccccccccccc}
+n\setminus k & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10 \\\\
+1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 & 1 \\\\
+2 & 2 & 1 & 2 & 1 & 2 & 1 & 2 & 1 & 2 & 1 \\\\
+3 & 3 & 3 & 2 & 2 & 1 & 1 & 3 & 3 & 2 & 2 \\\\
+4 & 4 & 1 & 1 & 2 & 2 & 3 & 2 & 3 & 3 & 4 \\\\
+5 & 5 & 3 & 4 & 1 & 2 & 4 & 4 & 1 & 2 & 4 \\\\
+6 & 6 & 5 & 1 & 5 & 1 & 4 & 5 & 3 & 5 & 2 \\\\
+7 & 7 & 7 & 4 & 2 & 6 & 3 & 5 & 4 & 7 & 5 \\\\
+8 & 8 & 1 & 7 & 6 & 3 & 1 & 4 & 4 & 8 & 7 \\\\
+9 & 9 & 3 & 1 & 1 & 8 & 7 & 2 & 3 & 8 & 8 \\\\
+10 & 10 & 5 & 4 & 5 & 3 & 3 & 9 & 1 & 7 & 8 \\\\
+\end{array}$$
 
 And here we can clearly see the following **pattern**:
 
@@ -44,7 +45,7 @@ So, we found a solution to the problem of Joseph, working in $O(n)$ operations.
 
 Simple **recursive implementation** (in 1-indexing)
 
-```
+```cpp
 int josephus(int n, int k) {
     return n > 1 ? (joseph(n-1, k) + k - 1) % n + 1 : 1;
 }
@@ -52,7 +53,7 @@ int josephus(int n, int k) {
 
 **Non-recursive form** :
 
-```
+```cpp
 int josephus(int n, int k) {
     int res = 0;
     for (int i = 1; i <= n; ++i)
@@ -81,7 +82,7 @@ Also, we need to handle the case when $n$ becomes less than $k$ - in this case, 
 
 **Implementation** (for convenience in 0-indexing):
 
-```
+```cpp
 int josephus(int n, int k) {
     if (n == 1)
         return 0;


### PR DESCRIPTION
Found some issues when poking at the book again. Binary exponentiation actually had an error even in the html version, otherwise it's all language annotations for code and fixes to make things more LaTeX friendly.

Speaking of the book. Sorry for not coming back to you after discussing things in my previous PR.  I tidied my stuff up a bit and created a [repo](https://github.com/algmyr/e-maxx-eng-book) for it. There are heaps of things to be improved, but it's a somewhat user friendly proof of concept.

(I've got no idea where I would mention something like the book repo. I decided on the PR since I was writing it anyway. Making an issue here to promote my repo just felt wrong.)