### PR TITLE
Problems sections should be subsections

### DIFF
--- a/src/data_structures/sqrt-tree.md
+++ b/src/data_structures/sqrt-tree.md
@@ -343,6 +343,6 @@ public:
 
 ~~~~~
 
-# Problems
+## Problems
 
 [CodeChef - SEGPROD](https://www.codechef.com/NOV17/problems/SEGPROD)

--- a/src/string/manacher.md
+++ b/src/string/manacher.md
@@ -159,6 +159,6 @@ for (int i = 0, l = 0, r = -1; i < n; i++) {
 }
 ```
 
-# Problems
+## Problems
 
 [UVA #11475 "Extend to Palindrome"](https://uva.onlinejudge.org/index.php?option=com_onlinejudge&Itemid=8&page=show_problem&problem=2470)


### PR DESCRIPTION
Some (two) of the problem listings were sections rather than subsections. This caused some spurious sections mentioned in https://github.com/algmyr/e-maxx-eng-book/issues/2.