### PR TITLE
More header fixes

### DIFF
--- a/src/algebra/balanced-ternary.md
+++ b/src/algebra/balanced-ternary.md
@@ -1,5 +1,5 @@
 <!--?title Balanced Ternary-->
-#Balanced Ternary
+# Balanced Ternary
 
 !["Setun computer using Balanced Ternary system"](http://ternary.3neko.ru/photo/setun1_small.jpg)
 

--- a/src/algebra/phi-function.md
+++ b/src/algebra/phi-function.md
@@ -1,5 +1,5 @@
 <!--?title Euler's totient function-->
-#Euler's totient function
+# Euler's totient function
 
 Euler's totient function, also known as **phi-function** $\phi (n)$, counts the number of integers between 1 and $n$ inclusive, which are coprime to $n$. Two numbers are coprime if their greatest common divisor equals $1$ ($1$ is considered to be coprime to any number).
 

--- a/src/contrib.md
+++ b/src/contrib.md
@@ -1,5 +1,5 @@
 <!--?title For Contributors-->
-#How to Contribute
+# How to Contribute
 
 ## General information
 
@@ -27,11 +27,11 @@ Please kindly refer to manuals on using `git` and `github` anywhere over interne
 <iframe width="420" height="315" src="https://www.youtube.com/embed/TrBBw4J9X30" frameborder="0" allowfullscreen></iframe>
 </div>
 
-##Your Authorship is Preserved
+## Your Authorship is Preserved
 
 Some contributors add explicit links to their profiles at the bottom of the translated articles. However it is discouraged and simply not very convenient if the article was edited by several people. Every page has `Page Authors` link in its top - this link leads to the github commit history, so it is always easy to determine or prove the authorship (even of any single line). Just make sure that your GitHub profile (which is mentioned in history) provides enough information about you.
 
-##Source format
+## Source format
 
 We use [Markdown](https://daringfireball.net/projects/markdown) for source texts and
 convert them automatically to HTML.
@@ -45,11 +45,11 @@ And here is the formula in the separate block:
 
 $$E = mc^{2}$$
 
-##Some conventions
+## Some conventions
 
 * We have agreed as of issue [#83](https://github.com/e-maxx-eng/e-maxx-eng/issues/83) to express binomial coefficients with `\binom{n}{k}` instead of `C_n^k`. The first one renders as $\binom{n}{k}$ and is a more universal convention. The second would render as $C_n^k$.
 
-##Adding images
+## Adding images
 
 Small images could be pushed along with texts to the [/img](https://github.com/e-maxx-eng/e-maxx-eng/tree/master/img) subfolder. Let them be in `PNG` format and less than `200kb`. Then you can refer to them inside the article with the tag:
 
@@ -75,7 +75,7 @@ And then link to it from the same or a different article:
     For more detail read the [Implementation](#implementation).
     More infos in [Impl. of Segmenttree](./data_structures/segment_tree.html#implementation).
 
-##Page Template
+## Page Template
 
 Template for the pages (the one which creates small violet header and footer, determines the layout of the text, includes css and js files) is now also stored in this repo, in [src/\_templates](https://github.com/e-maxx-eng/e-maxx-eng/tree/master/src/_templates) folder. So in case you find some bugs in it, or with the passing of time some new features may be needed in it - create PR to improve it. Note that for testing purposes the alternative template could be created and used for specific page with the inclusion of special comment as shown below:
 

--- a/src/demo-article.md
+++ b/src/demo-article.md
@@ -1,6 +1,6 @@
 <!--?title Demo Article-->
 
-#Demo Article
+# Demo Article
 
 _You can [see the source of this article](https://raw.githubusercontent.com/e-maxx-eng/e-maxx-eng/master/src/demo-article.md) to better understand formatting features._
 
@@ -33,7 +33,7 @@ the preceding paragraph <span class="toggle-code">Show/Hide</span>
 		return result;
 	}
 
-###TeX and Markdown references
+### TeX and Markdown references
 
 We use [Markdown](https://daringfireball.net/projects/markdown) for source texts and
 convert them automatically to HTML.
@@ -47,7 +47,7 @@ And here is the formula in the separate block:
 
 $$E = mc^{2}$$
 
-###Adding images
+### Adding images
 
 Small images could be pushed along with texts to the [/img](https://github.com/e-maxx-eng/e-maxx-eng/tree/master/img) subfolder. Let them be in `PNG` format and less than `200kb`. Then you can refer to them inside the article like this (see the source here):
 

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -1,6 +1,6 @@
 <!--?title Divide and Conquer DP-->
 
-#Divide and Conquer DP
+# Divide and Conquer DP
 
 Divide and Conquer is a dynamic programming optimization.
 

--- a/src/graph/strongly-connected-components.md
+++ b/src/graph/strongly-connected-components.md
@@ -1,6 +1,6 @@
 <!--?title Strongly Connected Components and Condensation graph -->
 
-#Finding strongly connected components<br/>Building condensation graph
+# Finding strongly connected components<br/>Building condensation graph
 
 ## Definitions
 You are given a directed graph $G$ with vertices $V$ and edges $E$. It is possible that there are loops and multiple edges. Let's denote $n$ as number of vertices and $m$ as number of edges in $G$.


### PR DESCRIPTION
Fixes some headers missed by #329.

Some were part of articles that actually broke in the pdf. The others were part of `contrib.md` and `demo-article.md` that I fixed just for the sake of consistency.