### PR TITLE
Add subsections to index

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -81,7 +81,7 @@ especially popular in field of competitive programming.*
 
 ### Linear Algebra
 
-- **Equation systems**
+- **Matrices**
     - [Gauss & System of Linear Equations](./linear_algebra/linear-system-gauss.html)
     - [Gauss & Determinant](./linear_algebra/determinant-gauss.html)
     - [Kraut & Determinant](./linear_algebra/determinant-kraut.html)
@@ -102,11 +102,6 @@ especially popular in field of competitive programming.*
     - [Placing Bishops on a Chessboard](./combinatorics/bishops-on-chessboard.html)
     - [Balanced bracket sequences](./combinatorics/bracket_sequences.html)
     - [Counting labeled graphs](./combinatorics/counting_labeled_graphs.html)
-
-### Game Theory
-
-- **Tasks**
-    - [Games on arbitrary graphs](./game_theory/games_on_graphs.html)
 
 ### Numerical Methods
 
@@ -196,27 +191,23 @@ especially popular in field of competitive programming.*
     - [2-SAT](./graph/2SAT.html)
     - [Heavy-light decomposition](./graph/hld.html)
 
-### Sequences
+### Miscellaneous
 
-- **Tasks**
+- **Sequences**
     - [RMQ task (Range Minimum Query - the smallest element in an interval)](./sequences/rmq.html)
     - [Longest increasing subsequence](./sequences/longest_increasing_subsequence.html)
+    - [Search the subsegment with the maximum/minimum sum](./others/maximum_average_segment.html)
     - [K-th order statistic in O(N)](./sequences/k-th.html)
-
-### Schedules
-
-- **Computing optimal schedules**
+- **Game Theory**
+    - [Games on arbitrary graphs](./game_theory/games_on_graphs.html)
+- **Schedules**
     - [Scheduling jobs on one machine](./schedules/schedule_one_machine.html)
     - [Scheduling jobs on two machines](./schedules/schedule_two_machines.html)
     - [Optimal schedule of jobs given their deadlines and durations](./schedules/schedule-with-completion-duration.html)
-
-### Miscellaneous
-
-- **Tasks**
+- **Miscellaneous**
     - [Josephus problem](./others/josephus_problem.html)
     - [15 Puzzle Game: Existence Of The Solution](./others/15-puzzle.html)
     - [The Stern-Brocot Tree and Farey Sequences](./others/stern_brocot_tree_farey_sequences.html)
-    - [Search the subsegment with the maximum/minimum sum](./others/maximum_average_segment.html)
 
 ---
 

--- a/src/index.md
+++ b/src/index.md
@@ -9,27 +9,37 @@ especially popular in field of competitive programming.*
 ## Articles
 
 ### Algebra
+
+#### Number-theoretic functions
+
 - [Euler's totient function](./algebra/phi-function.html)
 - [Number of divisors / sum of divisors](./algebra/divisors.html)
-- [Euclidean algorithm for computing the greatest common divisor](./algebra/euclid-algorithm.html)
+
+#### Prime numbers
 - [Sieve of Eratosthenes](./algebra/sieve-of-eratosthenes.html)
+- [Sieve of Eratosthenes Having Linear Time Complexity](./algebra/prime-sieve-linear.html)
+
+#### Modular arithmetic
+
+- [Modular Inverse](./algebra/module-inverse.html)
+- [Linear Congruence Equation](./algebra/linear_congruence_equation.html)
+- [Chinese Remainder Theorem](./algebra/chinese-remainder-theorem.html)
+- [Factorial modulo $p$](./algebra/factorial-modulo.html)
+
+
+- [Euclidean algorithm for computing the greatest common divisor](./algebra/euclid-algorithm.html)
 - [Extended Euclidean Algorithm](./algebra/extended-euclid-algorithm.html)
 - [Binary Exponentiation](./algebra/binary-exp.html)
 - [Balanced Ternary](./algebra/balanced-ternary.html)
 - [Linear Diophantine Equations](./algebra/linear-diophantine-equation.html)
-- [Linear Congruence Equation](./algebra/linear_congruence_equation.html)
-- [Modular Inverse](./algebra/module-inverse.html)
-- [Chinese Remainder Theorem](./algebra/chinese-remainder-theorem.html)
 - [Primitive Root](./algebra/primitive-root.html)
 - [Discrete Root](./algebra/discrete-root.html)
 - [Discrete Log](./algebra/discrete-log.html)
 - [Enumerating submasks of a bitmask](./algebra/all-submasks.html)
 - [Gray code](./algebra/gray-code.html)
-- [Sieve of Eratosthenes Having Linear Time Complexity](./algebra/prime-sieve-linear.html)
 - [Arbitrary-Precision Arithmetic](./algebra/big-integer.html)
 - [Fibonacci Numbers](./algebra/fibonacci-numbers.html)
 - [Finding Power of Factorial Divisor](./algebra/factorial-divisors.html)
-- [Factorial modulo $p$](./algebra/factorial-modulo.html)
 - [Fast Fourier transform](./algebra/fft.html)
 
 ### Data Structures
@@ -90,55 +100,92 @@ especially popular in field of competitive programming.*
 - [Integration by Simpson's formula](./num_methods/simpson-integration.html)
 
 ### Geometry
+
+#### Elementary algorithms, intersections
+
 - [Basic Geometry](./geometry/basic-geometry.html)
-- [Length of the union of segments](./geometry/length-of-segments-union.html)
-- [Oriented area of a triangle](./geometry/oriented-triangle-area.html)
-- [Intersection Point of Lines](./geometry/lines-intersection.html)
 - [Finding the equation of a line for a segment](./geometry/segment-to-line.html)
+- [Intersection Point of Lines](./geometry/lines-intersection.html)
 - [Check if two segments intersect](./geometry/check-segments-intersection.html)
 - [Intersection of Segments](./geometry/segments-intersection.html)
 - [Circle-Line Intersection](./geometry/circle-line-intersection.html)
 - [Circle-Circle Intersection](./geometry/circle-circle-intersection.html)
+- [Length of the union of segments](./geometry/length-of-segments-union.html)
+
+#### Polygons
+
+- [Oriented area of a triangle](./geometry/oriented-triangle-area.html)
+- [Area of simple polygon](./geometry/area-of-simple-polygon.html)
+- [Check if points belong to the convex polygon in O(log N)](./geometry/point-in-convex-polygon.html)
 - [Pick's Theorem - area of lattice polygons](./geometry/picks-theorem.html)
 - [Lattice points of non-lattice polygon](./geometry/lattice-points.html)
-- [Area of simple polygon](./geometry/area-of-simple-polygon.html)
-- [Convex hull trick and Li Chao tree](./geometry/convex_hull_trick.html)
+
+#### Convex hull
+
 - [Convex hull construction using Graham's Scan](./geometry/grahams-scan-convex-hull.html)
-- [Check if points belong to the convex polygon in O(log N)](./geometry/point-in-convex-polygon.html)
-- [Finding the nearest pair of points](./geometry/nearest_points.html)
+- [Convex hull trick and Li Chao tree](./geometry/convex_hull_trick.html)
+
+#### Sweep-line
+
 - [Search for a pair of intersecting segments](./geometry/intersecting_segments.html)
-- [Delaunay triangulation and Voronoi diagram](./geometry/delaunay.html)
 - [Point location in O(log N)](./geometry/point-location.html)
 
+#### Miscellaneous
+
+- [Finding the nearest pair of points](./geometry/nearest_points.html)
+- [Delaunay triangulation and Voronoi diagram](./geometry/delaunay.html)
+
 ### Graphs
+
+#### Graph traversal
+
 - [Breadth First Search](./graph/breadth-first-search.html)
 - [Depth First Search](./graph/depth-first-search.html)
-- [Bipartite Graph Check](./graph/bipartite-check.html)
-- [Topological Sorting](./graph/topological-sort.html)
+
+#### Connected components, bridges, articulations points
+
+- [Finding Connected Components](./graph/search-for-connected-components.html)
 - [Finding Bridges in O(N+M)](./graph/bridge-searching.html)
 - [Finding Bridges Online](./graph/bridge-searching-online.html)
 - [Finding Articulation Points in O(N+M)](./graph/cutpoints.html)
-- [Checking a graph for acyclicity and finding a cycle in O(M)](./graph/finding-cycle.html)
-- [Finding a Negative Cycle in the Graph](./graph/finding-negative-cycle-in-graph.html)
-- [Floyd-Warshall - finding all shortest paths](./graph/all-pair-shortest-path-floyd-warshall.html)
-- [Number of paths of fixed length / Shortest paths of fixed length](./graph/fixed_length_paths.html)
+- [Strongly Connected Components and Condensation Graph](./graph/strongly-connected-components.html)
+
+#### Single-source shortest paths
+
 - [Dijkstra - finding shortest paths from given vertex](./graph/dijkstra.html)
 - [Dijkstra on sparse graphs](./graph/dijkstra_sparse.html)
 - [Bellman-Ford - finding shortest paths with negative weights](./graph/bellman_ford.html)
 - [D´Esopo-Pape algorithm](./graph/desopo_pape.html)
-- [Finding Connected Components](./graph/search-for-connected-components.html)
+
+#### All-pairs shortest paths
+
+- [Floyd-Warshall - finding all shortest paths](./graph/all-pair-shortest-path-floyd-warshall.html)
+- [Number of paths of fixed length / Shortest paths of fixed length](./graph/fixed_length_paths.html)
+
+#### Spanning trees
+
+- [Minimum Spanning Tree - Prim's Algorithm](./graph/mst_prim.html)
+- [Minimum Spanning Tree - Kruskal](./graph/mst_kruskal.html)
+- [Minimum Spanning Tree - Kruskal with Disjoint Set Union](./graph/mst_kruskal_with_dsu.html)
+- [Kirchhoff Theorem](./graph/kirchhoff-theorem.html)
+- [Prüfer code](./graph/pruefer_code.html)
+
+#### Cycles
+
+- [Checking a graph for acyclicity and finding a cycle in O(M)](./graph/finding-cycle.html)
+- [Finding a Negative Cycle in the Graph](./graph/finding-negative-cycle-in-graph.html)
+- [Eulerian Path](./graph/euler_path.html)
+
+#### Lowest common ancestor
+
 - [Lowest Common Ancestor](./graph/lca.html)
 - [Lowest Common Ancestor - Binary Lifting](./graph/lca_binary_lifting.html)
 - [Lowest Common Ancestor - Farach-Colton and Bender algorithm](./graph/lca_farachcoltonbender.html)
 - [Solve RMQ by finding LCA](./graph/rmq_linear.html)
 - [Lowest Common Ancestor - Tarjan's off-line algorithm](./graph/lca_tarjan.html)
-- [Minimum Spanning Tree - Prim's Algorithm](./graph/mst_prim.html)
-- [Minimum Spanning Tree - Kruskal](./graph/mst_kruskal.html)
-- [Minimum Spanning Tree - Kruskal with Disjoint Set Union](./graph/mst_kruskal_with_dsu.html)
-- [Prüfer code](./graph/pruefer_code.html)
-- [Kirchhoff Theorem](./graph/kirchhoff-theorem.html)
-- [Eulerian Path](./graph/euler_path.html)
-- [Strongly Connected Components and Condensation Graph](./graph/strongly-connected-components.html)
+
+#### Flows and related problems
+
 - [Maximum flow - Ford-Fulkerson and Edmonds-Karp](./graph/edmonds_karp.html)
 - [Maximum flow - Push-relabel algorithm](./graph/push-relabel.html)
 - [Maximum flow - Push-relabel algorithm improved](./graph/push-relabel-faster.html)
@@ -147,6 +194,14 @@ especially popular in field of competitive programming.*
 - [Flows with demands](./graph/flow_with_demands.html)
 - [Minimum-cost flow](./graph/min_cost_flow.html)
 - [Assignment problem. Solution using min-cost-flow in O (N^5)](./graph/Assignment-problem-min-flow.html)
+
+#### Matchings and related problems
+
+- [Bipartite Graph Check](./graph/bipartite-check.html)
+
+#### Miscellaneous
+
+- [Topological Sorting](./graph/topological-sort.html)
 - [Edge connectivity / Vertex connectivity](./graph/edge_vertex_connectivity.html)
 - [Tree painting](./graph/tree_painting.html)
 - [2-SAT](./graph/2SAT.html)

--- a/src/index.md
+++ b/src/index.md
@@ -113,7 +113,7 @@ especially popular in field of competitive programming.*
 
 ### Geometry
 
-- **Elementary algorithms, intersections**
+- **Elementary operations**
     - [Basic Geometry](./geometry/basic-geometry.html)
     - [Finding the equation of a line for a segment](./geometry/segment-to-line.html)
     - [Intersection Point of Lines](./geometry/lines-intersection.html)

--- a/src/index.md
+++ b/src/index.md
@@ -1,5 +1,4 @@
 <!--?title Main Page-->
-
 <h1 data-toc="off">E-Maxx Algorithms in English</h1>
 
 *The goal of this project is to translate at least some pages of the wonderful resource
@@ -10,218 +9,214 @@ especially popular in field of competitive programming.*
 
 ### Algebra
 
-#### Number-theoretic functions
-
-- [Euler's totient function](./algebra/phi-function.html)
-- [Number of divisors / sum of divisors](./algebra/divisors.html)
-
-#### Prime numbers
-- [Sieve of Eratosthenes](./algebra/sieve-of-eratosthenes.html)
-- [Sieve of Eratosthenes Having Linear Time Complexity](./algebra/prime-sieve-linear.html)
-
-#### Modular arithmetic
-
-- [Modular Inverse](./algebra/module-inverse.html)
-- [Linear Congruence Equation](./algebra/linear_congruence_equation.html)
-- [Chinese Remainder Theorem](./algebra/chinese-remainder-theorem.html)
-- [Factorial modulo $p$](./algebra/factorial-modulo.html)
-
-
-- [Euclidean algorithm for computing the greatest common divisor](./algebra/euclid-algorithm.html)
-- [Extended Euclidean Algorithm](./algebra/extended-euclid-algorithm.html)
-- [Binary Exponentiation](./algebra/binary-exp.html)
-- [Balanced Ternary](./algebra/balanced-ternary.html)
-- [Linear Diophantine Equations](./algebra/linear-diophantine-equation.html)
-- [Primitive Root](./algebra/primitive-root.html)
-- [Discrete Root](./algebra/discrete-root.html)
-- [Discrete Log](./algebra/discrete-log.html)
-- [Enumerating submasks of a bitmask](./algebra/all-submasks.html)
-- [Gray code](./algebra/gray-code.html)
-- [Arbitrary-Precision Arithmetic](./algebra/big-integer.html)
-- [Fibonacci Numbers](./algebra/fibonacci-numbers.html)
-- [Finding Power of Factorial Divisor](./algebra/factorial-divisors.html)
-- [Fast Fourier transform](./algebra/fft.html)
+- **Fundamentals**
+    - [Binary Exponentiation](./algebra/binary-exp.html)
+    - [Euclidean algorithm for computing the greatest common divisor](./algebra/euclid-algorithm.html)
+    - [Extended Euclidean Algorithm](./algebra/extended-euclid-algorithm.html)
+    - [Linear Diophantine Equations](./algebra/linear-diophantine-equation.html)
+    - [Fibonacci Numbers](./algebra/fibonacci-numbers.html)
+- **Prime numbers**
+    - [Sieve of Eratosthenes](./algebra/sieve-of-eratosthenes.html)
+    - [Sieve of Eratosthenes Having Linear Time Complexity](./algebra/prime-sieve-linear.html)
+- **Number-theoretic functions**
+    - [Euler's totient function](./algebra/phi-function.html)
+    - [Number of divisors / sum of divisors](./algebra/divisors.html)
+- **Modular arithmetic**
+    - [Modular Inverse](./algebra/module-inverse.html)
+    - [Linear Congruence Equation](./algebra/linear_congruence_equation.html)
+    - [Chinese Remainder Theorem](./algebra/chinese-remainder-theorem.html)
+    - [Factorial modulo $p$](./algebra/factorial-modulo.html)
+    - [Discrete Root](./algebra/discrete-root.html)
+    - [Primitive Root](./algebra/primitive-root.html)
+    - [Discrete Log](./algebra/discrete-log.html)
+- **Number systems**
+    - [Balanced Ternary](./algebra/balanced-ternary.html)
+    - [Gray code](./algebra/gray-code.html)
+- **Miscellaneous**
+    - [Enumerating submasks of a bitmask](./algebra/all-submasks.html)
+    - [Arbitrary-Precision Arithmetic](./algebra/big-integer.html)
+    - [Fast Fourier transform](./algebra/fft.html)
 
 ### Data Structures
-- [Disjoint Set Union](./data_structures/disjoint_set_union.html)
-- [Fenwick Tree](./data_structures/fenwick.html)
-- [Sparse Table](./data_structures/sparse-table.html)
-- [Segment Tree](./data_structures/segment_tree.html)
-- [Treap](./data_structures/treap.html)
-- [Sqrt Decomposition](./data_structures/sqrt_decomposition.html)
-- [Sqrt Tree](./data_structures/sqrt-tree.html)
-- [Minimum Stack / Minimum Queue](./data_structures/stack_queue_modification.html)
-- [Randomized Heap](./data_structures/randomized_heap.html)
-- [Deleting from a data structure in O(T(n)log n)](./data_structures/deleting_in_log_n.html)
+
+- **Fundamentals**
+    - [Minimum Stack / Minimum Queue](./data_structures/stack_queue_modification.html)
+    - [Sparse Table](./data_structures/sparse-table.html)
+- **Trees**
+    - [Disjoint Set Union](./data_structures/disjoint_set_union.html)
+    - [Fenwick Tree](./data_structures/fenwick.html)
+    - [Sqrt Decomposition](./data_structures/sqrt_decomposition.html)
+    - [Segment Tree](./data_structures/segment_tree.html)
+    - [Treap](./data_structures/treap.html)
+    - [Sqrt Tree](./data_structures/sqrt-tree.html)
+    - [Randomized Heap](./data_structures/randomized_heap.html)
+- **Advanced**
+    - [Deleting from a data structure in O(T(n)log n)](./data_structures/deleting_in_log_n.html)
 
 ### Dynamic Programming
-- [Dynamic Programming on Broken Profile. Problem "Parquet"](./dynamic_programming/profile-dynamics.html)
-- [Finding the largest zero submatrix](./dynamic_programming/zero_matrix.html)
-- [Divide and Conquer DP](./dynamic_programming/divide-and-conquer-dp.html)
+
+- **DP optimizations**
+    - [Divide and Conquer DP](./dynamic_programming/divide-and-conquer-dp.html)
+- **Tasks**
+    - [Dynamic Programming on Broken Profile. Problem "Parquet"](./dynamic_programming/profile-dynamics.html)
+    - [Finding the largest zero submatrix](./dynamic_programming/zero_matrix.html)
 
 ### String Processing
-- [String Hashing](./string/string-hashing.html)
-- [Rabin-Karp for String Matching](./string/rabin-karp.html)
-- [Expression parsing](./string/expression_parsing.html)
-- [Suffix Array](./string/suffix-array.html)
-- [Suffix Tree](./string/suffix-tree-ukkonen.html)
-- [Suffix Automaton](./string/suffix-automaton.html)
-- [Z-function](./string/z-function.html)
-- [Prefix function](./string/prefix-function.html)
-- [Finding all sub-palindromes in O(N)](./string/manacher.html)
-- [Lyndon factorization](./string/lyndon_factorization.html)
-- [Aho-Corasick algorithm](./string/aho_corasick.html)
-- [Finding repetitions](./string/main_lorentz.html)
+
+- **Fundamentals**
+    - [String Hashing](./string/string-hashing.html)
+    - [Rabin-Karp for String Matching](./string/rabin-karp.html)
+    - [Prefix function](./string/prefix-function.html)
+    - [Z-function](./string/z-function.html)
+    - [Suffix Array](./string/suffix-array.html)
+    - [Aho-Corasick algorithm](./string/aho_corasick.html)
+- **Advanced**
+    - [Suffix Tree](./string/suffix-tree-ukkonen.html)
+    - [Suffix Automaton](./string/suffix-automaton.html)
+    - [Lyndon factorization](./string/lyndon_factorization.html)
+- **Tasks**
+    - [Expression parsing](./string/expression_parsing.html)
+    - [Finding all sub-palindromes in O(N)](./string/manacher.html)
+    - [Finding repetitions](./string/main_lorentz.html)
 
 ### Linear Algebra
-- [Gauss & System of Linear Equations](./linear_algebra/linear-system-gauss.html)
-- [Gauss & Determinant](./linear_algebra/determinant-gauss.html)
-- [Kraut & Determinant](./linear_algebra/determinant-kraut.html)
-- [Rank of a matrix](./linear_algebra/rank-matrix.html)
+
+- **Equation systems**
+    - [Gauss & System of Linear Equations](./linear_algebra/linear-system-gauss.html)
+    - [Gauss & Determinant](./linear_algebra/determinant-gauss.html)
+    - [Kraut & Determinant](./linear_algebra/determinant-kraut.html)
+    - [Rank of a matrix](./linear_algebra/rank-matrix.html)
 
 ### Combinatorics
-- [The Inclusion-Exclusion Principle](./combinatorics/inclusion-exclusion.html)
-- [Binomial Coefficients](./combinatorics/binomial-coefficients.html)
-- [Catalan Numbers](./combinatorics/catalan-numbers.html)
-- [Placing Bishops on a Chessboard](./combinatorics/bishops-on-chessboard.html)
-- [Balanced bracket sequences](./combinatorics/bracket_sequences.html)
-- [Counting labeled graphs](./combinatorics/counting_labeled_graphs.html)
-- [Burnside's lemma / Pólya enumeration theorem](./combinatorics/burnside.html)
-- [Stars and bars](./combinatorics/stars_and_bars.html)
-- [Generating all $K$-combinations](./combinatorics/generating_combinations.html)
+
+- **Fundamentals**
+    - [Finding Power of Factorial Divisor](./algebra/factorial-divisors.html)
+    - [Binomial Coefficients](./combinatorics/binomial-coefficients.html)
+    - [Catalan Numbers](./combinatorics/catalan-numbers.html)
+- **Techniques**
+    - [The Inclusion-Exclusion Principle](./combinatorics/inclusion-exclusion.html)
+    - [Burnside's lemma / Pólya enumeration theorem](./combinatorics/burnside.html)
+    - [Stars and bars](./combinatorics/stars_and_bars.html)
+    - [Generating all $K$-combinations](./combinatorics/generating_combinations.html)
+- **Tasks**
+    - [Placing Bishops on a Chessboard](./combinatorics/bishops-on-chessboard.html)
+    - [Balanced bracket sequences](./combinatorics/bracket_sequences.html)
+    - [Counting labeled graphs](./combinatorics/counting_labeled_graphs.html)
 
 ### Game Theory
 
-- [Games on arbitrary graphs](./game_theory/games_on_graphs.html)
+- **Tasks**
+    - [Games on arbitrary graphs](./game_theory/games_on_graphs.html)
 
 ### Numerical Methods
-- [Ternary Search](./num_methods/ternary_search.html)
-- [Newton's method for finding roots](./num_methods/roots_newton.html)
-- [Integration by Simpson's formula](./num_methods/simpson-integration.html)
+
+- **Search**
+    - [Ternary Search](./num_methods/ternary_search.html)
+    - [Newton's method for finding roots](./num_methods/roots_newton.html)
+- **Integration**
+    - [Integration by Simpson's formula](./num_methods/simpson-integration.html)
 
 ### Geometry
 
-#### Elementary algorithms, intersections
-
-- [Basic Geometry](./geometry/basic-geometry.html)
-- [Finding the equation of a line for a segment](./geometry/segment-to-line.html)
-- [Intersection Point of Lines](./geometry/lines-intersection.html)
-- [Check if two segments intersect](./geometry/check-segments-intersection.html)
-- [Intersection of Segments](./geometry/segments-intersection.html)
-- [Circle-Line Intersection](./geometry/circle-line-intersection.html)
-- [Circle-Circle Intersection](./geometry/circle-circle-intersection.html)
-- [Length of the union of segments](./geometry/length-of-segments-union.html)
-
-#### Polygons
-
-- [Oriented area of a triangle](./geometry/oriented-triangle-area.html)
-- [Area of simple polygon](./geometry/area-of-simple-polygon.html)
-- [Check if points belong to the convex polygon in O(log N)](./geometry/point-in-convex-polygon.html)
-- [Pick's Theorem - area of lattice polygons](./geometry/picks-theorem.html)
-- [Lattice points of non-lattice polygon](./geometry/lattice-points.html)
-
-#### Convex hull
-
-- [Convex hull construction using Graham's Scan](./geometry/grahams-scan-convex-hull.html)
-- [Convex hull trick and Li Chao tree](./geometry/convex_hull_trick.html)
-
-#### Sweep-line
-
-- [Search for a pair of intersecting segments](./geometry/intersecting_segments.html)
-- [Point location in O(log N)](./geometry/point-location.html)
-
-#### Miscellaneous
-
-- [Finding the nearest pair of points](./geometry/nearest_points.html)
-- [Delaunay triangulation and Voronoi diagram](./geometry/delaunay.html)
+- **Elementary algorithms, intersections**
+    - [Basic Geometry](./geometry/basic-geometry.html)
+    - [Finding the equation of a line for a segment](./geometry/segment-to-line.html)
+    - [Intersection Point of Lines](./geometry/lines-intersection.html)
+    - [Check if two segments intersect](./geometry/check-segments-intersection.html)
+    - [Intersection of Segments](./geometry/segments-intersection.html)
+    - [Circle-Line Intersection](./geometry/circle-line-intersection.html)
+    - [Circle-Circle Intersection](./geometry/circle-circle-intersection.html)
+    - [Length of the union of segments](./geometry/length-of-segments-union.html)
+- **Polygons**
+    - [Oriented area of a triangle](./geometry/oriented-triangle-area.html)
+    - [Area of simple polygon](./geometry/area-of-simple-polygon.html)
+    - [Check if points belong to the convex polygon in O(log N)](./geometry/point-in-convex-polygon.html)
+    - [Pick's Theorem - area of lattice polygons](./geometry/picks-theorem.html)
+    - [Lattice points of non-lattice polygon](./geometry/lattice-points.html)
+- **Convex hull**
+    - [Convex hull construction using Graham's Scan](./geometry/grahams-scan-convex-hull.html)
+    - [Convex hull trick and Li Chao tree](./geometry/convex_hull_trick.html)
+- **Sweep-line**
+    - [Search for a pair of intersecting segments](./geometry/intersecting_segments.html)
+    - [Point location in O(log N)](./geometry/point-location.html)
+- **Miscellaneous**
+    - [Finding the nearest pair of points](./geometry/nearest_points.html)
+    - [Delaunay triangulation and Voronoi diagram](./geometry/delaunay.html)
 
 ### Graphs
 
-#### Graph traversal
-
-- [Breadth First Search](./graph/breadth-first-search.html)
-- [Depth First Search](./graph/depth-first-search.html)
-
-#### Connected components, bridges, articulations points
-
-- [Finding Connected Components](./graph/search-for-connected-components.html)
-- [Finding Bridges in O(N+M)](./graph/bridge-searching.html)
-- [Finding Bridges Online](./graph/bridge-searching-online.html)
-- [Finding Articulation Points in O(N+M)](./graph/cutpoints.html)
-- [Strongly Connected Components and Condensation Graph](./graph/strongly-connected-components.html)
-
-#### Single-source shortest paths
-
-- [Dijkstra - finding shortest paths from given vertex](./graph/dijkstra.html)
-- [Dijkstra on sparse graphs](./graph/dijkstra_sparse.html)
-- [Bellman-Ford - finding shortest paths with negative weights](./graph/bellman_ford.html)
-- [D´Esopo-Pape algorithm](./graph/desopo_pape.html)
-
-#### All-pairs shortest paths
-
-- [Floyd-Warshall - finding all shortest paths](./graph/all-pair-shortest-path-floyd-warshall.html)
-- [Number of paths of fixed length / Shortest paths of fixed length](./graph/fixed_length_paths.html)
-
-#### Spanning trees
-
-- [Minimum Spanning Tree - Prim's Algorithm](./graph/mst_prim.html)
-- [Minimum Spanning Tree - Kruskal](./graph/mst_kruskal.html)
-- [Minimum Spanning Tree - Kruskal with Disjoint Set Union](./graph/mst_kruskal_with_dsu.html)
-- [Kirchhoff Theorem](./graph/kirchhoff-theorem.html)
-- [Prüfer code](./graph/pruefer_code.html)
-
-#### Cycles
-
-- [Checking a graph for acyclicity and finding a cycle in O(M)](./graph/finding-cycle.html)
-- [Finding a Negative Cycle in the Graph](./graph/finding-negative-cycle-in-graph.html)
-- [Eulerian Path](./graph/euler_path.html)
-
-#### Lowest common ancestor
-
-- [Lowest Common Ancestor](./graph/lca.html)
-- [Lowest Common Ancestor - Binary Lifting](./graph/lca_binary_lifting.html)
-- [Lowest Common Ancestor - Farach-Colton and Bender algorithm](./graph/lca_farachcoltonbender.html)
-- [Solve RMQ by finding LCA](./graph/rmq_linear.html)
-- [Lowest Common Ancestor - Tarjan's off-line algorithm](./graph/lca_tarjan.html)
-
-#### Flows and related problems
-
-- [Maximum flow - Ford-Fulkerson and Edmonds-Karp](./graph/edmonds_karp.html)
-- [Maximum flow - Push-relabel algorithm](./graph/push-relabel.html)
-- [Maximum flow - Push-relabel algorithm improved](./graph/push-relabel-faster.html)
-- [Maximum flow - Dinic's algorithm](./graph/dinic.html)
-- [Maximum flow - MPM algorithm](./graph/mpm.html)
-- [Flows with demands](./graph/flow_with_demands.html)
-- [Minimum-cost flow](./graph/min_cost_flow.html)
-- [Assignment problem. Solution using min-cost-flow in O (N^5)](./graph/Assignment-problem-min-flow.html)
-
-#### Matchings and related problems
-
-- [Bipartite Graph Check](./graph/bipartite-check.html)
-
-#### Miscellaneous
-
-- [Topological Sorting](./graph/topological-sort.html)
-- [Edge connectivity / Vertex connectivity](./graph/edge_vertex_connectivity.html)
-- [Tree painting](./graph/tree_painting.html)
-- [2-SAT](./graph/2SAT.html)
-- [Heavy-light decomposition](./graph/hld.html)
+- **Graph traversal**
+    - [Breadth First Search](./graph/breadth-first-search.html)
+    - [Depth First Search](./graph/depth-first-search.html)
+- **Connected components, bridges, articulations points**
+    - [Finding Connected Components](./graph/search-for-connected-components.html)
+    - [Finding Bridges in O(N+M)](./graph/bridge-searching.html)
+    - [Finding Bridges Online](./graph/bridge-searching-online.html)
+    - [Finding Articulation Points in O(N+M)](./graph/cutpoints.html)
+    - [Strongly Connected Components and Condensation Graph](./graph/strongly-connected-components.html)
+- **Single-source shortest paths**
+    - [Dijkstra - finding shortest paths from given vertex](./graph/dijkstra.html)
+    - [Dijkstra on sparse graphs](./graph/dijkstra_sparse.html)
+    - [Bellman-Ford - finding shortest paths with negative weights](./graph/bellman_ford.html)
+    - [D´Esopo-Pape algorithm](./graph/desopo_pape.html)
+- **All-pairs shortest paths**
+    - [Floyd-Warshall - finding all shortest paths](./graph/all-pair-shortest-path-floyd-warshall.html)
+    - [Number of paths of fixed length / Shortest paths of fixed length](./graph/fixed_length_paths.html)
+- **Spanning trees**
+    - [Minimum Spanning Tree - Prim's Algorithm](./graph/mst_prim.html)
+    - [Minimum Spanning Tree - Kruskal](./graph/mst_kruskal.html)
+    - [Minimum Spanning Tree - Kruskal with Disjoint Set Union](./graph/mst_kruskal_with_dsu.html)
+    - [Kirchhoff Theorem](./graph/kirchhoff-theorem.html)
+    - [Prüfer code](./graph/pruefer_code.html)
+- **Cycles**
+    - [Checking a graph for acyclicity and finding a cycle in O(M)](./graph/finding-cycle.html)
+    - [Finding a Negative Cycle in the Graph](./graph/finding-negative-cycle-in-graph.html)
+    - [Eulerian Path](./graph/euler_path.html)
+- **Lowest common ancestor**
+    - [Lowest Common Ancestor](./graph/lca.html)
+    - [Lowest Common Ancestor - Binary Lifting](./graph/lca_binary_lifting.html)
+    - [Lowest Common Ancestor - Farach-Colton and Bender algorithm](./graph/lca_farachcoltonbender.html)
+    - [Solve RMQ by finding LCA](./graph/rmq_linear.html)
+    - [Lowest Common Ancestor - Tarjan's off-line algorithm](./graph/lca_tarjan.html)
+- **Flows and related problems**
+    - [Maximum flow - Ford-Fulkerson and Edmonds-Karp](./graph/edmonds_karp.html)
+    - [Maximum flow - Push-relabel algorithm](./graph/push-relabel.html)
+    - [Maximum flow - Push-relabel algorithm improved](./graph/push-relabel-faster.html)
+    - [Maximum flow - Dinic's algorithm](./graph/dinic.html)
+    - [Maximum flow - MPM algorithm](./graph/mpm.html)
+    - [Flows with demands](./graph/flow_with_demands.html)
+    - [Minimum-cost flow](./graph/min_cost_flow.html)
+    - [Assignment problem. Solution using min-cost-flow in O (N^5)](./graph/Assignment-problem-min-flow.html)
+- **Matchings and related problems**
+    - [Bipartite Graph Check](./graph/bipartite-check.html)
+- **Miscellaneous**
+    - [Topological Sorting](./graph/topological-sort.html)
+    - [Edge connectivity / Vertex connectivity](./graph/edge_vertex_connectivity.html)
+    - [Tree painting](./graph/tree_painting.html)
+    - [2-SAT](./graph/2SAT.html)
+    - [Heavy-light decomposition](./graph/hld.html)
 
 ### Sequences
-- [RMQ task (Range Minimum Query - the smallest element in an interval)](./sequences/rmq.html)
-- [Longest increasing subsequence](./sequences/longest_increasing_subsequence.html)
-- [K-th order statistic in O(N)](./sequences/k-th.html)
+
+- **Tasks**
+    - [RMQ task (Range Minimum Query - the smallest element in an interval)](./sequences/rmq.html)
+    - [Longest increasing subsequence](./sequences/longest_increasing_subsequence.html)
+    - [K-th order statistic in O(N)](./sequences/k-th.html)
 
 ### Schedules
-- [Scheduling jobs on one machine](./schedules/schedule_one_machine.html)
-- [Scheduling jobs on two machines](./schedules/schedule_two_machines.html)
-- [Optimal schedule of jobs given their deadlines and durations](./schedules/schedule-with-completion-duration.html)
+
+- **Computing optimal schedules**
+    - [Scheduling jobs on one machine](./schedules/schedule_one_machine.html)
+    - [Scheduling jobs on two machines](./schedules/schedule_two_machines.html)
+    - [Optimal schedule of jobs given their deadlines and durations](./schedules/schedule-with-completion-duration.html)
 
 ### Miscellaneous
-- [Josephus problem](./others/josephus_problem.html)
-- [15 Puzzle Game: Existence Of The Solution](./others/15-puzzle.html)
-- [The Stern-Brocot Tree and Farey Sequences](./others/stern_brocot_tree_farey_sequences.html)
-- [Search the subsegment with the maximum/minimum sum](./others/maximum_average_segment.html)
+
+- **Tasks**
+    - [Josephus problem](./others/josephus_problem.html)
+    - [15 Puzzle Game: Existence Of The Solution](./others/15-puzzle.html)
+    - [The Stern-Brocot Tree and Farey Sequences](./others/stern_brocot_tree_farey_sequences.html)
+    - [Search the subsegment with the maximum/minimum sum](./others/maximum_average_segment.html)
 
 ---
 


### PR DESCRIPTION
Implementation for #285. 
It will look like this: [link](https://jakobkogler.github.io/index.html)

e-maxx.ru only had subsections for 3 sections (Graphs, Geometry, and Algebra), but that would look just stupid. So I added subsections for all sections. Some look a little bit odd, because there is only one subsection per section. Maybe we should combine some of them (e.g. combining Miscellaneous, Schedules, Sequences and Game Theory in one big sections).

Please tell me if you are happy with it or not. And what your thoughts are.
@madhur4127 @RodionGork 