### PR TITLE
Fix typo in string hashing

### DIFF
--- a/src/string/string-hashing.md
+++ b/src/string/string-hashing.md
@@ -46,7 +46,7 @@ For example, if the input is composed of only lowercase letters of English alpha
 If the input may contain both uppercase and lowercase letters, then $p = 53$ is a possible choice.
 The code in this article will use $p = 31$.
 
-Obviously $m$ should be a large number, since the probability of two random strings colliding is about $\approx \frac{1}{p}$.
+Obviously $m$ should be a large number, since the probability of two random strings colliding is about $\approx \frac{1}{m}$.
 Sometimes $m = 2^{64}$ is chosen, since then the integer overflows of 64 bit integers work exactly like the modulo operation.
 However there exists a method, which generates colliding strings (which work independent from the choice of $p$).
 So in practice $m = 2^{64}$ is not recommended.


### PR DESCRIPTION
I think it should be pretty clear that the probability of collisions is 1/modulo, not 1/base.