### PR TITLE
Fixed segment tree query function

### DIFF
--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -760,7 +760,7 @@ void update(int v, int tl, int tr, int l, int r, int addend) {
 int query(int v, int tl, int tr, int l, int r) {
     if (l > r)
         return -INF;
-    if (tl == tr)
+    if (l <= tl && tr <= r)
         return t[v];
     push(v);
     int tm = (tl + tr) / 2;


### PR DESCRIPTION
In the case of adding on segments and querying for maximum, the query function did not work in logarithmic time.