### PR TITLE
Fixed typo in Heavy-light decomposition

### DIFF
--- a/src/graph/hld.md
+++ b/src/graph/hld.md
@@ -25,7 +25,7 @@ $$
 
 All other edges are labeled **light**.
 
-It is obvious that at most one heavy edge can emanate from one vertex downward, because otherwise the vertex $v$ would have at least two children of size $\ge \frac{s(v)}{2}$, but size of subtree of $v$, $s(v) \ge 1 + 2 \frac{s(v)}{2}$ which leads to a contradiction.
+It is obvious that at most one heavy edge can emanate from one vertex downward, because otherwise the vertex $v$ would have at least two children of size $\ge \frac{s(v)}{2}$, and therefore the the size of subtree of $v$ would be to big, $s(v) \ge 1 + 2 \frac{s(v)}{2} > s(v)$, which leads to a contradiction.
 
 Now we will decompose the tree into disjoint paths. Consider all the vertices from which no heavy edges come down. We will go up from each such vertex until we reach the root of the tree or go through a light edge. As a result, we will get several paths which are made up of zero or more heavy edges plus one light edge. The path which has an end at the root is an exception to this and will not have a light edge. Let these be called **heavy paths** - these are the desired paths of heavy-light decomposition.
 

--- a/src/graph/hld.md
+++ b/src/graph/hld.md
@@ -25,7 +25,7 @@ $$
 
 All other edges are labeled **light**.
 
-It is obvious that at most one heavy edge can emanate from one vertex downward, because otherwise the vertex $v$ would have at least two children of size $\ge \frac{s(v)}{2}$, but size of subtree of $v$, $s(v) < 1 + 2 \frac{s(v)}{2}$ which leads to a contradiction.
+It is obvious that at most one heavy edge can emanate from one vertex downward, because otherwise the vertex $v$ would have at least two children of size $\ge \frac{s(v)}{2}$, but size of subtree of $v$, $s(v) > 1 + 2 \frac{s(v)}{2}$ which leads to a contradiction.
 
 Now we will decompose the tree into disjoint paths. Consider all the vertices from which no heavy edges come down. We will go up from each such vertex until we reach the root of the tree or go through a light edge. As a result, we will get several paths which are made up of zero or more heavy edges plus one light edge. The path which has an end at the root is an exception to this and will not have a light edge. Let these be called **heavy paths** - these are the desired paths of heavy-light decomposition.
 

--- a/src/graph/hld.md
+++ b/src/graph/hld.md
@@ -25,7 +25,7 @@ $$
 
 All other edges are labeled **light**.
 
-It is obvious that at most one heavy edge can emanate from one vertex downward, because otherwise the vertex $v$ would have at least two children of size $\ge \frac{s(v)}{2}$, but size of subtree of $v$, $s(v) > 1 + 2 \frac{s(v)}{2}$ which leads to a contradiction.
+It is obvious that at most one heavy edge can emanate from one vertex downward, because otherwise the vertex $v$ would have at least two children of size $\ge \frac{s(v)}{2}$, but size of subtree of $v$, $s(v) \ge 1 + 2 \frac{s(v)}{2}$ which leads to a contradiction.
 
 Now we will decompose the tree into disjoint paths. Consider all the vertices from which no heavy edges come down. We will go up from each such vertex until we reach the root of the tree or go through a light edge. As a result, we will get several paths which are made up of zero or more heavy edges plus one light edge. The path which has an end at the root is an exception to this and will not have a light edge. Let these be called **heavy paths** - these are the desired paths of heavy-light decomposition.
 


### PR DESCRIPTION
There is a small mistake in the inequality sign in line 28 of Heavy-light Decomposition article. Fixed that!