### PR TITLE
Fix in tangents-to-two-circles, removing escaped parentheses

### DIFF
--- a/src/geometry/tangents-to-two-circles.md
+++ b/src/geometry/tangents-to-two-circles.md
@@ -49,8 +49,8 @@ $$a \cdot v_x + b \cdot v_y + c = d_2$$
 
 The solution of this system is reduced to solving a quadratic equation. We will omit all the cumbersome calculations, and immediately give a ready answer:
 
-$$a = {\( d_2 - d_1 \) v_x \pm v_y \sqrt{v_x^2 + v_y^2-(d_2-d_1)^2} \over {v_x^2 + v_y^2} }$$
-$$b = {\( d_2 - d_1 \) v_y \pm v_x \sqrt{v_x^2 + v_y^2-(d_2-d_1)^2} \over {v_x^2 + v_y^2} }$$
+$$a = {( d_2 - d_1 ) v_x \pm v_y \sqrt{v_x^2 + v_y^2-(d_2-d_1)^2} \over {v_x^2 + v_y^2} }$$
+$$b = {( d_2 - d_1 ) v_y \pm v_x \sqrt{v_x^2 + v_y^2-(d_2-d_1)^2} \over {v_x^2 + v_y^2} }$$
 $$c = d_1$$
 
 Total we got eight solutions instead four. However, it is easy to understand where superfluous decisions arise: in fact, in the latter system, it is enough to take only one solution (for example, the first). In fact, the geometric meaning of what we take $\pm r_1$ and $\pm r_2$ is clear: we are actually sorting out which side of each circle there is a straight line. Therefore, the two methods that arise when solving the latter system are redundant: it is enough to choose one of the two solutions (only, of course, in all four cases, you must choose the same family of solutions).


### PR DESCRIPTION
Parens should not be escaped, `\(` and `\)` are math delimiters.