### PR TITLE
Fix condition in line 89 in discrete-root.md

### DIFF
--- a/src/algebra/discrete-root.md
+++ b/src/algebra/discrete-root.md
@@ -86,7 +86,7 @@ int generator(int p) {
 	for (int res = 2; res <= p; ++res) {
 		bool ok = true;
 		for (int factor : fact) {
-			if (powmod(res, phi / factor, p) != 1) {
+			if (powmod(res, phi / factor, p) == 1) {
 				ok = false;
 				break;
 			}


### PR DESCRIPTION
In line 89: the condition was " != 1", but it should be " == 1" because if it is equal one then ok will be false (as res isn't primitive root) and will search for another primitive root.

Here is a simple test for this change:
A test inputs 11 2 4 (meaning x^2 = 4 (mod 11))
x is obviously 2 and 9.
Here is the correct output (after this modification: https://ideone.com/yFrWSc
Here is the incorrect output (before this modification): https://ideone.com/EeUVHI