### PR TITLE
Fixed a bug in implementation

### DIFF
--- a/src/data_structures/disjoint_set_union.md
+++ b/src/data_structures/disjoint_set_union.md
@@ -273,7 +273,7 @@ Therefore the complexity will be $O(\log n)$ per union (which is also quite fast
 Implementation:
 
 ```cpp
-for (int i = 0; i < L; i++) {
+for (int i = 0; i <= L; i++) {
     make_set(i);
 }
 


### PR DESCRIPTION
Without " <= ", function find_set( int ) would go into infinite recursion, since we need parent[ L ] to be equal to L.