### PR TITLE
Use emplace_back instead of push_back

### DIFF
--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -81,8 +81,8 @@ struct Dinic {
     }
 
     void add_edge(int v, int u, long long cap) {
-        edges.push_back(FlowEdge(v, u, cap));
-        edges.push_back(FlowEdge(u, v, 0));
+        edges.emplace_back(v, u, cap);
+        edges.emplace_back(u, v, 0);
         adj[v].push_back(m);
         adj[u].push_back(m + 1);
         m += 2;


### PR DESCRIPTION
Would like to propose this change as emplace_back is a bit fast than push_back and avoids temporary variable creation.