### PR TITLE
correct the ending index in the trivial algo for KMP prefix function

### DIFF
--- a/src/string/prefix-function.md
+++ b/src/string/prefix-function.md
@@ -25,7 +25,7 @@ vector<int> prefix_function(string s) {
     vector<int> pi(n);
     for (int i = 0; i < n; i++)
         for (int k = 0; k <= i; k++)
-            if (s.substr(0, k) == s.substr(i-k+1, k))
+            if (s.substr(0, k) == s.substr(i-k+1, i+1))
                 pi[i] = k;
     return pi;
 }


### PR DESCRIPTION
The trivial implementation for constructing the prefix function in the KMP has a typo in the trailing index of the second substring.  This pull request corrects that ending index.