### PR TITLE
Update the function for calculating the square root

### DIFF
--- a/src/num_methods/roots_newton.md
+++ b/src/num_methods/roots_newton.md
@@ -28,7 +28,7 @@ The rate of convergence is quadratic, which, conditionally speaking, means that 
 
 Let's use the calculation of square root as an example of Newton's method.
 
-If we substitute $f(x) = \sqrt{x}$, then after simplifying the expression, we get:
+If we substitute $f(x) = x^2 - n$, then after simplifying the expression, we get:
 
 $$ x_{i+1} = \frac{x_i + \frac{n}{x_i}}{2} $$
 


### PR DESCRIPTION
I understood the [original article](http://e-maxx.ru/algo/roots_newton) in Russian also used sqrt as the function for calculating the square root. However, I think the correct function here should be x^2 instead, and it is worth a correction. 