### PR TITLE
fix incorrect position of code in fibonacci-numbers.md

### DIFF
--- a/src/algebra/fibonacci-numbers.md
+++ b/src/algebra/fibonacci-numbers.md
@@ -107,7 +107,6 @@ $$ \begin{array}{rll}
 \end{array}$$
 Thus using above two equations Fibonacci numbers can be calculated easily by the following code:
 
-The above code returns $F_n$ and $F_{n+1}$ as a pair.
 ```cpp
 pair<int, int> fib (int n) {
     if (n == 0)
@@ -122,6 +121,7 @@ pair<int, int> fib (int n) {
         return {c, d};
 }
 ```
+The above code returns $F_n$ and $F_{n+1}$ as a pair.
 
 ## Periodicity modulo p
 


### PR DESCRIPTION
Under section **fast doubling method**
The code should be above `The above code returns Fn and Fn+1 as a pair.`
Before:
![image](https://user-images.githubusercontent.com/37617951/64259610-00873780-cf47-11e9-82d4-899a3322d247.png)


After: 
![Screenshot from 2019-09-04 19-00-51](https://user-images.githubusercontent.com/37617951/64259415-a25a5480-cf46-11e9-859b-a29b23220b5f.png)

