### PR TITLE
Fixed an indentation error in bellman_ford.md

### DIFF
--- a/src/graph/bellman_ford.md
+++ b/src/graph/bellman_ford.md
@@ -109,7 +109,7 @@ void solve()
                     p[e[j].b] = e[j].a;
                     any = true;
                 }
-                if (!any)  break;
+        if (!any)  break;
     }
 
     if (d[t] == INF)


### PR DESCRIPTION
In the retrieving path section, the indentation in the break clause of bellman ford was misleading.