### PR TITLE
Fix for issue #461

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -29,6 +29,9 @@ body {
     padding: 10px;
     border-radius: 3px;
 }
+#footer {
+    margin-top: 16px;
+}
 #navbar #title {
     font-size: 200%;
     display: inline-block;
@@ -73,7 +76,7 @@ code {
     color: #449;
 }
 pre {
-    margin: 0px 10px;
+    margin: 16px 10px;
     padding: 5px;
     border-radius: 5px;
     background: #e8e8e8;


### PR DESCRIPTION
On some pages like [this](https://cp-algorithms.com/graph/finding-cycle.html) one, the `pre` code block touches the footer.

As a simple fix, I added top and bottom margin of 16px for `pre` and top-margin of 16px for `#footer`. I chose 16px as the value because other elements like `p` and `ul` have same margins for them. So this would look consistent across the website.