### PR TITLE
remove redundancy

### DIFF
--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -94,7 +94,6 @@ Since we know that the module operator doesn't interfere with multiplications ($
 
 ```cpp
 long long binpow(long long a, long long b, long long m) {
-    a %= m;
     long long res = 1;
     while (b > 0) {
         if (b & 1)


### PR DESCRIPTION
on the first example of binary exp there is no need to a %= m