### PR TITLE
Added return statement in the code of spfa

### DIFF
--- a/src/graph/bellman_ford.md
+++ b/src/graph/bellman_ford.md
@@ -254,6 +254,7 @@ bool spfa(int s, vector<int>& d) {
             }
         }
     }
+    return true;
 }
 ```
 


### PR DESCRIPTION
I ran ```test.sh``` and found a bug of the current spfa implementation.

```
In file included from test_spfa.cpp:7:
spfa.h: In function ‘bool spfa(int, std::vector<int>&)’:
spfa.h:35:1: warning: control reaches end of non-void function [-Wreturn-type]
   35 | }
      | ^
44 / 44 tests were successful.
```

It's a bool function that returns false if it detects negative cycle.
However, it has no "return true;" statement at the end of function.
If there is no negative cycle, the return value is uncertain.
