### PR TITLE
Add practice problem for Suffix Automaton

### DIFF
--- a/src/string/suffix-automaton.md
+++ b/src/string/suffix-automaton.md
@@ -715,3 +715,4 @@ After that, the answer to the problem will be the string $longest(v)$ for the st
 
   - [SPOJ - SUBLEX](https://www.spoj.com/problems/SUBLEX/)
   - [Codeforces - Cyclical Quest](https://codeforces.com/problemset/problem/235/C)
+  - [Codeforces - String](https://codeforces.com/contest/128/problem/B)


### PR DESCRIPTION
[This problem](https://codeforces.com/contest/128/problem/B) is essentially finding the k-th (in the lexicographical order) substring of the given string, but with duplicates allowed (which is different from the example in the article).

For example, given string `aa` (first test case), the lexicographically ordered list of all substrings is `a`, `a`, `aa`.
In the article, only first occurence of `a` counts, so the second one would be removed. However, with some modifications we can still solve this problem with Suffix Automaton.

I can provide my solution in C++ if needed.

Thank you!