### PR TITLE
Update bridge searching online

### DIFF
--- a/src/graph/bridge-searching-online.md
+++ b/src/graph/bridge-searching-online.md
@@ -188,16 +188,20 @@ void merge_path (int a, int b) {
         if (a != -1) {
             a = find_2ecc(a);
             path_a.push_back(a);
-            if (last_visit[a] == lca_iteration)
+            if (last_visit[a] == lca_iteration){
                 lca = a;
+                break;
+                }
             last_visit[a] = lca_iteration;
             a = par[a];
         }
         if (b != -1) {
-            path_b.push_back(b);
             b = find_2ecc(b);
-            if (last_visit[b] == lca_iteration)
+            path_b.push_back(b);
+            if (last_visit[b] == lca_iteration){
                 lca = b;
+                break;
+                }
             last_visit[b] = lca_iteration;
             b = par[b];
         }


### PR DESCRIPTION
Since we are adding 'b' instead of the 2-edge-connected representative of 'b', it may be possible that we will count extra bridges (to be deleted) than actual.
More details: https://discuss.codechef.com/t/ac-on-one-platform-rejected-on-another-and-vice-versa/66410