### PR TITLE
Corrected misplaced bracket

### DIFF
--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -88,7 +88,7 @@ Thus the implementation is very simple:
 ```cpp
 inv[1] = 1;
 for(int i = 2; i < m; ++i)
-    inv[i] = (m - (m/i) * inv[m%i] % m) % m;
+    inv[i] = ((m - m/i) * inv[m%i] % m) % m;
 ```
 
 ### Proof


### PR DESCRIPTION
In the code for modular inverse for every number
line no 3
given formula :  inv[i] = (m - (m/i) * inv[m%i] % m) %m
correct forumla : inv[i] = ((m - m/i) * inv[m%i] % m) %m