### PR TITLE
Mentioned Knuth-Morris-Pratt in index.md

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -74,7 +74,7 @@ and adding new articles to the collection.*
 - **Fundamentals**
     - [String Hashing](./string/string-hashing.html)
     - [Rabin-Karp for String Matching](./string/rabin-karp.html)
-    - [Prefix function](./string/prefix-function.html)
+    - [Prefix function - Knuth-Morris-Pratt](./string/prefix-function.html)
     - [Z-function](./string/z-function.html)
     - [Suffix Array](./string/suffix-array.html)
     - [Aho-Corasick algorithm](./string/aho_corasick.html)


### PR DESCRIPTION
The [Prefix function](./string/prefix-function.html) article's name in `index.md` should also mention the name "Knuth-Morris-Pratt" as this is the name by which algorithm is rather popular. Otherwise, it is difficult to find the article for those looking solely for KMP.