### PR TITLE
Update string-hashing.md

### DIFF
--- a/src/string/string-hashing.md
+++ b/src/string/string-hashing.md
@@ -167,7 +167,7 @@ int count_unique_substrings(string const& s) {
         set<long long> hs;
         for (int i = 0; i <= n - l; i++) {
             long long cur_h = (h[i + l] + m - h[i]) % m;
-            cur_h = (cur_h * p_pow[n-i-1]) % m;
+            cur_h = (cur_h * p_pow[n-i-l]) % m;
             hs.insert(cur_h);
         }
         cnt += hs.size();


### PR DESCRIPTION
on line 170, cur_h should be multiplied with p_pow[n-i-l] (l for lion), for example for a string "abcqrcqrm", the substring are not being multiplied with the same power of p if few cases.