### PR TITLE
clearer explanation of base cases for suffix links

### DIFF
--- a/src/string/aho_corasick.md
+++ b/src/string/aho_corasick.md
@@ -99,7 +99,7 @@ while from the current vertex of the trie there is no transition using the curre
 Thus we reduced the problem of constructing an automaton to the problem of finding suffix links for all vertices of the trie.
 However we will build these suffix links, oddly enough, using the transitions constructed in the automaton.
 
-Note that if we want to find a suffix link for some vertex $v$, then we can go to the ancestor $p$ of the current vertex (let $c$ be the letter of the edge from $p$ to $v$), then follow its suffix link, and perform from there the transition with the letter $c$.
+Note that if we want to find a suffix link for some vertex $v$, then we have firstly have the base cases that the root vertex has suffix link itself, and all nodes that are children of the root vertex (i.e the vertices associated with prefixes of length one) also have suffix link the root vertex. Moreover, the suffix link of all deeper vertices can be evaluated as follows: we can go to the ancestor $p$ of this current vertex (let $c$ be the letter of the edge from $p$ to $v$), then follow its suffix link, and perform from there the transition with the letter $c$.
 
 Thus the problem of finding the transitions has been reduced to the problem of finding suffix links, and the problem of finding suffix links has been reduced to the problem of finding a suffix link and a transition, but for vertices closer to the root.
 So we have a recursive dependence that we can resolve in linear time.


### PR DESCRIPTION
This more clearly reflects the lines of code 

```cpp
        if (v == 0 || t[v].p == 0)
            t[v].link = 0;
```

I think it's clear that the suffix link of the root is the root, but it was less clear to me at first that the suffix link of the children of the root was the root from reading the explanation alone.