### PR TITLE
Minor debugging in implementation of Assignment-problem-min-flow.

### DIFF
--- a/src/graph/Assignment-problem-min-flow.md
+++ b/src/graph/Assignment-problem-min-flow.md
@@ -38,7 +38,7 @@ vector<int> assignment(vector<vector<int>> a) {
         queue<int> q;
         dist[s] = 0;
         p[s] = -1;
-        q.push_back(s);
+        q.push(s);
         while (!q.empty()) {
             int v = q.front();
             q.pop();


### PR DESCRIPTION
push_back() is no method of std::queue. We use push() instead of it.