### PR TITLE
Changed the return type of 'decompose' function

### DIFF
--- a/src/graph/hld.md
+++ b/src/graph/hld.md
@@ -126,7 +126,7 @@ int dfs(int v, vector<vector<int>> const& adj) {
     return size;
 }
 
-int decompose(int v, int h, vector<vector<int>> const& adj) {
+void decompose(int v, int h, vector<vector<int>> const& adj) {
     head[v] = h, pos[v] = cur_pos++;
     if (heavy[v] != -1)
         decompose(heavy[v], h, adj);


### PR DESCRIPTION
The decompose function does not return anything, so changed from 'int' to 'void'.