### PR TITLE
correcting the formula

### DIFF
--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -90,7 +90,7 @@ Compute $x^n \bmod m$.
 This is a very common operation. For instance it is used in computing the [modular multiplicative inverse](./algebra/module-inverse.html).
 
 **Solution:**
-Since we know that the module operator doesn't interfere with multiplications ($a \cdot b \equiv (a \bmod m) \cdot (b \bmod m) \pmod m$), we can directly use the same code, and just replace every multiplication with a modular multiplication:
+Since we know that the module operator doesn't interfere with multiplications ($(a \cdot b)\bmod m \equiv (a \bmod m) \cdot (b \bmod m) \pmod m$), we can directly use the same code, and just replace every multiplication with a modular multiplication:
 
 ```cpp
 long long binpow(long long a, long long b, long long m) {


### PR DESCRIPTION
The formula mentioned is not correct(`a⋅b≡(amodm)⋅(bmodm)(modm))`). LHS is missing mod m.
