### PR TITLE
fix missing clear on order vector

### DIFF
--- a/src/graph/2SAT.md
+++ b/src/graph/2SAT.md
@@ -122,6 +122,7 @@ void dfs2(int v, int cl) {
 }
 
 bool solve_2SAT() {
+    order.clear();
     used.assign(n, false);
     for (int i = 0; i < n; ++i) {
         if (!used[i])


### PR DESCRIPTION
The `order` vector needs to be cleared when `solve_2SAT` is called.

The current code does take care of resetting `used` and `comp` vectors so it is only fair that `order` vector gets reset too.