### PR TITLE
Fix the upper bound of one-based idx Fenwick

### DIFF
--- a/src/data_structures/fenwick.md
+++ b/src/data_structures/fenwick.md
@@ -294,7 +294,7 @@ struct FenwickTreeOneBasedIndexing {
     }
 
     void add(int idx, int delta) {
-        for (++idx; idx < n; idx += idx & -idx)
+        for (++idx; idx <= n; idx += idx & -idx)
             bit[idx] += delta;
     }
 };


### PR DESCRIPTION
Otherwise the update cannot reach to the top of the tree IMHO.