### PR TITLE
Fix Divide And Conquer DP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 *.swp
 *.sublime-project
 *.sublime-workspace
+converted.html
+converted.pdf

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -43,16 +43,17 @@ It has to be called with `compute(0, n-1, 0, n-1)`.
 
 ```cpp divide_and_conquer_dp
 int n;
-long long C(int i, int j);
 vector<long long> dp_before(n), dp_cur(n);
 
+long long C(int i, int j);
+
 // compute dp_cur[l], ... dp_cur[r] (inclusive)
-void compute(int l, int r, int optl, int optr)
-{
+void compute(int l, int r, int optl, int optr){
     if (l > r)
         return;
+
     int mid = (l + r) >> 1;
-    pair<long long, int> best = {INF, -1};
+    pair<long long, int> best = {LLONG_MAX, -1};
 
     for (int k = optl; k <= min(mid, optr); k++) {
         best = min(best, {dp_before[k] + C(k, mid), k});

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -75,24 +75,25 @@ with the Convex Hull trick or vice-versa. It is useful to know and understand
 both!
 
 ## Practice Problems
-- [Dunjudge - GUARDS](https://dunjudge.me/analysis/problems/894/) (This is the exact problem in this article.)
-- [Codeforces - Ciel and Gondolas](https://codeforces.com/contest/321/problem/E) (Be careful with I/O!)
-- [SPOJ - LARMY](https://www.spoj.com/problems/LARMY/)
-- [SPOJ - NKLEAVES](https://www.spoj.com/problems/NKLEAVES/)
-- [SPOJ - ADAMOLD](https://www.spoj.com/problems/ADAMOLD/)
-- [Codechef - CHEFAOR](https://www.codechef.com/problems/CHEFAOR)
-- [Hackerrank - Guardians of the Lunatics](https://www.hackerrank.com/contests/ioi-2014-practice-contest-2/challenges/guardians-lunatics-ioi14)
-- [Hackerrank - Mining](https://www.hackerrank.com/contests/world-codesprint-5/challenges/mining)
-- [ACM ICPC World Finals 2017 - Money](https://open.kattis.com/problems/money)
-- [CodeForces - Partition Game](https://codeforces.com/contest/1527/problem/E)
+- [AtCoder - Yakiniku Restaurants](https://atcoder.jp/contests/arc067/tasks/arc067_d)
+- [CodeForces - Ciel and Gondolas](https://codeforces.com/contest/321/problem/E) (Be careful with I/O!)
 - [CodeForces - Levels And Regions](https://codeforces.com/problemset/problem/673/E)
+- [CodeForces - Partition Game](https://codeforces.com/contest/1527/problem/E)
 - [CodeForces - The Bakery](https://codeforces.com/problemset/problem/834/D)
 - [CodeForces - Yet Another Minimization Problem](https://codeforces.com/contest/868/problem/F)
+- [Codechef - CHEFAOR](https://www.codechef.com/problems/CHEFAOR)
+- [Dunjudge - GUARDS](https://dunjudge.me/analysis/problems/894/) (This is the exact problem in this article.)
+- [Hackerrank - Guardians of the Lunatics](https://www.hackerrank.com/contests/ioi-2014-practice-contest-2/challenges/guardians-lunatics-ioi14)
+- [Hackerrank - Mining](https://www.hackerrank.com/contests/world-codesprint-5/challenges/mining)
+- [Kattis - Money (ACM ICPC World Finals 2017)](https://open.kattis.com/problems/money)
+- [SPOJ - ADAMOLD](https://www.spoj.com/problems/ADAMOLD/)
+- [SPOJ - LARMY](https://www.spoj.com/problems/LARMY/)
+- [SPOJ - NKLEAVES](https://www.spoj.com/problems/NKLEAVES/)
 - [Timus - Bicolored Horses](https://acm.timus.ru/problem.aspx?space=1&num=1167)
+- [USACO - Circular Barn](http://www.usaco.org/index.php?page=viewproblem2&cpid=616)
 - [UVA - Arranging Heaps](https://onlinejudge.org/external/125/12524.pdf)
 - [UVA - Naming Babies](https://onlinejudge.org/external/125/12594.pdf)
-- [AtCoder - Yakiniku Restaurants](https://atcoder.jp/contests/arc067/tasks/arc067_d)
-- [USACO - Circular Barn](http://www.usaco.org/index.php?page=viewproblem2&cpid=616)
+
 
 
 ## References

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -39,16 +39,16 @@ levels.
 Even though implementation varies based on problem, here's a fairly generic
 template.
 The function `compute` computes one row $i$ of states `dp_cur`, given the previous row $i-1$ of states `dp_before`.
-It has to be called with `compute(0, n-1, 0, n-1)`.
+It has to be called with `compute(0, n-1, 0, n-1)`. The function `solve` computes `m` rows and returns the result.
 
 ```cpp divide_and_conquer_dp
-int n;
+int m, n;
 vector<long long> dp_before(n), dp_cur(n);
 
 long long C(int i, int j);
 
 // compute dp_cur[l], ... dp_cur[r] (inclusive)
-void compute(int l, int r, int optl, int optr){
+void compute(int l, int r, int optl, int optr) {
     if (l > r)
         return;
 
@@ -64,6 +64,18 @@ void compute(int l, int r, int optl, int optr){
 
     compute(l, mid - 1, optl, opt);
     compute(mid + 1, r, opt, optr);
+}
+
+int solve() {
+    for (int i = 0; i < n; i++)
+        dp_before[i] = C(0, i);
+
+    for (int i = 1; i < m; i++) {
+        compute(0, n - 1, 0, n - 1);
+        dp_before = dp_cur;
+    }
+
+    return dp_before[n - 1];
 }
 ```
 

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -56,7 +56,7 @@ void compute(int l, int r, int optl, int optr){
     pair<long long, int> best = {LLONG_MAX, -1};
 
     for (int k = optl; k <= min(mid, optr); k++) {
-        best = min(best, {dp_before[k - 1] + C(k, mid), k});
+        best = min(best, {(k ? dp_before[k - 1] : 0) + C(k, mid), k});
     }
 
     dp_cur[mid] = best.first;

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -78,9 +78,22 @@ both!
 - [Dunjudge - GUARDS](https://dunjudge.me/analysis/problems/894/) (This is the exact problem in this article.)
 - [Codeforces - Ciel and Gondolas](https://codeforces.com/contest/321/problem/E) (Be careful with I/O!)
 - [SPOJ - LARMY](https://www.spoj.com/problems/LARMY/)
+- [SPOJ - NKLEAVES](https://www.spoj.com/problems/NKLEAVES/)
+- [SPOJ - ADAMOLD](https://www.spoj.com/problems/ADAMOLD/)
 - [Codechef - CHEFAOR](https://www.codechef.com/problems/CHEFAOR)
 - [Hackerrank - Guardians of the Lunatics](https://www.hackerrank.com/contests/ioi-2014-practice-contest-2/challenges/guardians-lunatics-ioi14)
+- [Hackerrank - Mining](https://www.hackerrank.com/contests/world-codesprint-5/challenges/mining)
 - [ACM ICPC World Finals 2017 - Money](https://open.kattis.com/problems/money)
+- [CodeForces - Partition Game](https://codeforces.com/contest/1527/problem/E)
+- [CodeForces - Levels And Regions](https://codeforces.com/problemset/problem/673/E)
+- [CodeForces - The Bakery](https://codeforces.com/problemset/problem/834/D)
+- [CodeForces - Yet Another Minimization Problem](https://codeforces.com/contest/868/problem/F)
+- [Timus - Bicolored Horses](https://acm.timus.ru/problem.aspx?space=1&num=1167)
+- [UVA - Arranging Heaps](https://onlinejudge.org/external/125/12524.pdf)
+- [UVA - Naming Babies](https://onlinejudge.org/external/125/12594.pdf)
+- [AtCoder - Yakiniku Restaurants](https://atcoder.jp/contests/arc067/tasks/arc067_d)
+- [USACO - Circular Barn](http://www.usaco.org/index.php?page=viewproblem2&cpid=616)
+
 
 ## References
 - [Quora Answer by Michael Levin](https://www.quora.com/What-is-divide-and-conquer-optimization-in-dynamic-programming)

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -56,7 +56,7 @@ void compute(int l, int r, int optl, int optr){
     pair<long long, int> best = {LLONG_MAX, -1};
 
     for (int k = optl; k <= min(mid, optr); k++) {
-        best = min(best, {dp_before[k] + C(k, mid), k});
+        best = min(best, {dp_before[k - 1] + C(k, mid), k});
     }
 
     dp_cur[mid] = best.first;

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -6,16 +6,16 @@ Divide and Conquer is a dynamic programming optimization.
 
 ### Preconditions
 Some dynamic programming problems have a recurrence of this form: $$dp(i, j) =
-\min_{k \leq j} \\{ dp(i - 1, k) + C(k, j) \\}$$ where $C(k, j)$ is some cost
-function. 
+\min_{0 \leq k \leq j} \\{ dp(i - 1, k - 1) + C(k, j) \\}$$ Where $C(k, j)$ is a cost
+function and $dp(i, j) = 0$ when $j \lt 0$.
 
-Say $1 \leq i \leq m$ and $1 \leq j \leq n$, and evaluating $C$ takes $O(1)$
-time. Straightforward evaluation of the above recurrence is $O(m n^2)$. There
+Say $0 \leq i \lt m$ and $0 \leq j \lt n$, and evaluating $C$ takes $O(1)$
+time. Then the straightforward evaluation of the above recurrence is $O(m n^2)$. There
 are $m \times n$ states, and $n$ transitions for each state.
 
 Let $opt(i, j)$ be the value of $k$ that minimizes the above expression. If
 $opt(i, j) \leq opt(i, j + 1)$ for all $i, j$, then we can apply
-divide-and-conquer DP. This known as the _monotonicity condition_. The optimal
+divide-and-conquer DP. This is known as the _monotonicity condition_. The optimal
 "splitting point" for a fixed $i$ increases as $j$ increases.
 
 This lets us solve for all states more efficiently. Say we compute $opt(i, j)$

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -41,7 +41,7 @@ template.
 The function `compute` computes one row $i$ of states `dp_cur`, given the previous row $i-1$ of states `dp_before`.
 It has to be called with `compute(0, n-1, 0, n-1)`.
 
-```cpp
+```cpp divide_and_conquer_dp
 int n;
 long long C(int i, int j);
 vector<long long> dp_before(n), dp_cur(n);

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+script_start=`date +%s%N`
+
 python extract_snippets.py
 
 if [ -z "$CXX" ];
@@ -6,34 +9,49 @@ then
     CXX=g++
 fi
 
-TESTS=0
-SUCCESS=0
+red=`tput setaf 1`
+green=`tput setaf 2`
+no_color=`tput sgr0`
+
+total=0
+success=0
+
 for cppfile in *.cpp;
 do
-    TESTS=$((TESTS + 1))
+    echo -n "Running $cppfile - "
+
+    total=$((total + 1))
+    start=`date +%s%N`
+
     $CXX -std=c++11 $cppfile -o $cppfile.out 
     COMPILATION=$?
     if [ $COMPILATION -eq 0 ];
     then
         ./$cppfile.out
-        TEST_SUCCESS=$?
-        if [ $TEST_SUCCESS -eq 0 ];
+        test_success=$?
+        if [ $test_success -eq 0 ];
         then
-            SUCCESS=$((SUCCESS + 1))
+            success=$((success + 1))
+            end=`date +%s%N`
+            echo ${green}Passed in $(((end - $start)/1000000)) ms${no_color}
         else
-            echo "Test $cppfile failed!"
+            echo ${red}"Test $cppfile failed!"${no_color}
         fi
-    else
-        echo "Error while compiling $cppfile!"
-    fi
 
-    rm $cppfile.out
+        rm $cppfile.out
+    else
+        echo ${red}"Error while compiling $cppfile!"${no_color}
+    fi
 done
 
-echo "$SUCCESS / $TESTS tests were successful."
-if [ $SUCCESS -eq $TESTS ];
+script_end=`date +%s%N`
+time_taken=$(echo "$script_start $script_end" | awk '{printf "%.2f\n", ($2-$1)/1000000000.0}')
+
+if [ $success -eq $total ];
 then
+    echo ${green}"\n$success PASSED in $time_taken seconds${no_color}"
     exit 0
 else
+    echo ${red}"\n$(($total - $success)) FAILED, ${green}$success PASSED${red} in $time_taken seconds${no_color}"
     exit 1
 fi

--- a/test/test_divide_and_conquer_dp.cpp
+++ b/test/test_divide_and_conquer_dp.cpp
@@ -8,45 +8,22 @@ using namespace std;
 
 vector<int> ar;
 
-int solve(int k) {
-    n = ar.size();
-    dp_before.resize(n, 0), dp_cur.resize(n, 0);
+/// O(m * n^2) DP, ignoring complexity of C(i, j)
+int brute_force() {
+    for (int j = 0; j < n; j++)
+        dp_before[j] = C(0, j);
 
-    for (int i = 0; i < n; i++)
-        dp_before[i] = C(0, i);
-
-    for (int i = 1; i < k; i++) {
-        compute(0, n - 1, 0, n - 1);
+    for (int i = 1; i < m; i++) {
+        for (int j = 0; j < n; j++) {
+            dp_cur[j] = INT_MAX;
+            for (int k = 0; k <= j; k++) {
+                dp_cur[j] = min(dp_cur[j], (k ? dp_before[k - 1] : 0) + C(k, j));
+            }
+        }
         dp_before = dp_cur;
     }
 
     return dp_before[n - 1];
-}
-
-/// O(n^2 * k) DP, ignoring complexity of C(i, j)
-int brute_force(int k) {
-    const int INF = 1 << 25;
-
-    n = ar.size();
-    vector<long long> dp[2];
-
-    dp[0].resize(n + 1), dp[1].resize(n + 1);
-    for (int i = 0; i < n; i++)
-        dp[0][i] = dp[1][i] = INF;
-
-    for (int j = 1; j <= k; j++) {
-        int cur = j & 1;
-        int prev = cur ^ 1;
-
-        for (int i = 0; i < n; i++) {
-            dp[cur][i] = INF;
-            for (int l = i; l < n; l++) {
-                dp[cur][i] = min(dp[cur][i], dp[prev][l + 1] + C(i, l));
-            }
-        }
-    }
-
-    return dp[k & 1][0];
 }
 
 // sum of last occurrence of x - first occurence of x for all unique x in the range
@@ -64,24 +41,38 @@ long long C(int i, int j) {
     return cost;
 }
 
-int main() {
+void test_handcrafted_case() {
     ar = vector<int>({
       32, 8, 32, 32, 32, 34, 38, 38, 39, 32, 22, 29, 39,
       5, 5, 32, 5, 32, 32, 22, 10, 22, 8, 35, 38, 23, 29,
       9, 8, 29, 34, 32, 11, 29, 22, 32, 38, 38, 32,
     });
 
-    assert(solve(3) == 30);
+    m = 3;
+    n = ar.size();
+    dp_before.resize(n, 0), dp_cur.resize(n, 0);
 
+    assert(solve() == 30);
+}
+
+void test_random_cases(int t, int maxn, int maxv) {
     mt19937 rng(0);
-    for (int i = 0; i < 100; i++) {
-        int n = rng() % 10 + 1;
+    for (int i = 0; i < t; i++) {
+        n = rng() % maxn + 1;
+        dp_before.resize(n, 0), dp_cur.resize(n, 0);
+
         ar.clear();
         for (int i = 0; i < n; i++)
-            ar.push_back(rng() % 5 + 1);
+            ar.push_back(rng() % maxv + 1);
 
-        for (int k = 1; k <= n; k++) {
-            assert(solve(k) == brute_force(k));
+        for (m = 1; m <= n; m++) {
+            assert(solve() == brute_force());
         }
     }
+}
+
+int main() {
+    test_handcrafted_case();
+    test_random_cases(100, 10, 5);
+    return 0;
 }

--- a/test/test_divide_and_conquer_dp.cpp
+++ b/test/test_divide_and_conquer_dp.cpp
@@ -1,0 +1,89 @@
+// https://codeforces.com/contest/1527/problem/E
+
+#include <bits/stdc++.h>
+
+using namespace std;
+
+#include "divide_and_conquer_dp.h"
+
+vector<int> ar;
+
+int solve(int k)
+{
+    n = ar.size();
+    dp_before.resize(n, 0), dp_cur.resize(n, 0);
+
+    for (int i = 0; i < n; i++)
+        dp_before[i] = C(0, i);
+
+    for (int i = 1; i < k; i++) {
+        compute(0, n - 1, 0, n - 1);
+        dp_before = dp_cur;
+    }
+
+    return dp_before[n - 1];
+}
+
+/// O(n^2 * k) DP
+int brute_force(int k)
+{
+    const int INF = 1 << 25;
+
+    n = ar.size();
+    vector<long long> dp[2];
+
+    dp[0].resize(n + 1), dp[1].resize(n + 1);
+    for (int i = 0; i < n; i++)
+        dp[0][i] = dp[1][i] = INF;
+
+    for (int j = 1; j <= k; j++) {
+        int cur = j & 1;
+        int prev = cur ^ 1;
+
+        for (int i = 0; i < n; i++) {
+            dp[cur][i] = INF;
+            for (int l = i; l < n; l++) {
+                dp[cur][i] = min(dp[cur][i], dp[prev][l + 1] + C(i, l));
+            }
+        }
+    }
+
+    return dp[k & 1][0];
+}
+
+// sum of last occurrence of x - first occurence of x for all unique x in the range
+long long C(int i, int j)
+{
+    map<int, int> last;
+
+    int cost = 0;
+    for (int l = i; l <= j; l++) {
+        int x = ar[l];
+        if (last.count(x))
+            cost += (l - last[x]);
+        last[x] = l;
+    }
+
+    return cost;
+}
+
+int main()
+{
+    ar = vector<int>({ 32, 8, 32, 32, 32, 34, 38, 38, 39, 32, 22, 29, 39,
+        5, 5, 32, 5, 32, 32, 22, 10, 22, 8, 35, 38, 23,
+        29, 9, 8, 29, 34, 32, 11, 29, 22, 32, 38, 38, 32 });
+
+    assert(solve(3) == 30);
+
+    mt19937 rng(0);
+    for (int i = 0; i < 1000; i++) {
+        int n = rng() % 10 + 1;
+        ar.clear();
+        for (int i = 0; i < n; i++)
+            ar.push_back(rng() % 10 + 1);
+
+        for (int k = 1; k <= n; k++) {
+            assert(solve(k) == brute_force(k));
+        }
+    }
+}

--- a/test/test_divide_and_conquer_dp.cpp
+++ b/test/test_divide_and_conquer_dp.cpp
@@ -8,8 +8,7 @@ using namespace std;
 
 vector<int> ar;
 
-int solve(int k)
-{
+int solve(int k) {
     n = ar.size();
     dp_before.resize(n, 0), dp_cur.resize(n, 0);
 
@@ -24,9 +23,8 @@ int solve(int k)
     return dp_before[n - 1];
 }
 
-/// O(n^2 * k) DP
-int brute_force(int k)
-{
+/// O(n^2 * k) DP, ignoring complexity of C(i, j)
+int brute_force(int k) {
     const int INF = 1 << 25;
 
     n = ar.size();
@@ -52,8 +50,7 @@ int brute_force(int k)
 }
 
 // sum of last occurrence of x - first occurence of x for all unique x in the range
-long long C(int i, int j)
-{
+long long C(int i, int j) {
     map<int, int> last;
 
     int cost = 0;
@@ -67,20 +64,21 @@ long long C(int i, int j)
     return cost;
 }
 
-int main()
-{
-    ar = vector<int>({ 32, 8, 32, 32, 32, 34, 38, 38, 39, 32, 22, 29, 39,
-        5, 5, 32, 5, 32, 32, 22, 10, 22, 8, 35, 38, 23,
-        29, 9, 8, 29, 34, 32, 11, 29, 22, 32, 38, 38, 32 });
+int main() {
+    ar = vector<int>({
+      32, 8, 32, 32, 32, 34, 38, 38, 39, 32, 22, 29, 39,
+      5, 5, 32, 5, 32, 32, 22, 10, 22, 8, 35, 38, 23, 29,
+      9, 8, 29, 34, 32, 11, 29, 22, 32, 38, 38, 32,
+    });
 
     assert(solve(3) == 30);
 
     mt19937 rng(0);
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 100; i++) {
         int n = rng() % 10 + 1;
         ar.clear();
         for (int i = 0; i < n; i++)
-            ar.push_back(rng() % 10 + 1);
+            ar.push_back(rng() % 5 + 1);
 
         for (int k = 1; k <= n; k++) {
             assert(solve(k) == brute_force(k));


### PR DESCRIPTION
This PR reverts the incorrectly fixed typo in https://github.com/e-maxx-eng/e-maxx-eng/pull/402/commits/d0082f4860f346fffaaeefeeecb446d632a5026d as part of PR https://github.com/e-maxx-eng/e-maxx-eng/pull/402.

Doing ```best = min(best, {dp_before[k] + C(k, mid), k});``` is just wrong, because here both segments overlap as they are inclusive. But overlapping is not allowed as an element can belong to at most one partition. https://github.com/e-maxx-eng/e-maxx-eng/pull/712/commits/e134b20905bb960c6e77209fa85ad7d2e4c44b6f should fix it.

This snippet didn't have any tests. As a result, the incorrectly fixed typo got undetected for more than two years! So added tests to prevent such scenarios from happening in the first place going forward.

While running the tests locally, I noticed that as the script is running, we have no idea of knowing which test is being executed and how much time it takes. Hence took the liberty to improve the test runner in https://github.com/e-maxx-eng/e-maxx-eng/pull/712/commits/62f2d434427148a1b6aec42ec1bdd7ccd53f2f6a. The script will now show which test is currently running along with the execution time. Something like the following:

![Screenshot from 2021-05-31 19-00-05](https://user-images.githubusercontent.com/29172543/120197091-6f8be000-c242-11eb-8468-4e90a1680142.png)


Also, refactored the snippet a bit and added more practice problems.