### PR TITLE
Fix typo in Factorial modulo

### DIFF
--- a/src/algebra/factorial-modulo.md
+++ b/src/algebra/factorial-modulo.md
@@ -20,7 +20,7 @@ Let's write this modified factorial explicitly.
 $$\begin{eqnarray}
 n!_{\%p} &=& 1 \cdot 2 \cdot 3 \cdot \ldots \cdot (p-2) \cdot (p-1) \cdot \underbrace{1}\_{p} \cdot (p+1) \cdot (p+2) \cdot \ldots \cdot (2p-1) \cdot \underbrace{2}\_{2p} \\\
  & &\quad \cdot (2p+1) \cdot \ldots \cdot (p^2-1) \cdot \underbrace{1}\_{p^2} \cdot (p^2 +1) \cdot \ldots \cdot n \pmod{p} \\\\
-&=& 1 \cdot 2 \cdot 3 \cdot \ldots \cdot (p-2) \cdot (p-1) \cdot \underbrace{1}\_{p} \cdot 2 \cdot \ldots \cdot (p-1) \cdot \underbrace{2}\_{2p} \cdot 1 \cdot 2 \\\
+&=& 1 \cdot 2 \cdot 3 \cdot \ldots \cdot (p-2) \cdot (p-1) \cdot \underbrace{1}\_{p} \cdot 1 \cdot 2 \cdot \ldots \cdot (p-1) \cdot \underbrace{2}\_{2p} \cdot 1 \cdot 2 \\\
 & &\quad \cdot \ldots \cdot (p-1) \cdot \underbrace{1}\_{p^2} \cdot 1 \cdot 2 \cdot \ldots \cdot (n \bmod p) \pmod{p}
 \end{eqnarray}$$
 
@@ -76,7 +76,7 @@ int factmod(int n, int p) {
         res = res * f[n%p] % p;
         n /= p;
     }
-    return res; 
+    return res;
 }
 ```
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/17219541/125734494-d994303c-6b60-43ac-9284-5325fca3877d.png)

After:

![image](https://user-images.githubusercontent.com/17219541/125734513-bd6e905b-0696-43c9-a3f5-bb431a8438e9.png)