### PR TITLE
Fix tex on suffix-array page

### DIFF
--- a/src/_templates/default.html
+++ b/src/_templates/default.html
@@ -8,6 +8,14 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="./js/common.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script>
+      MathJax.Hub.Config({
+        tex2jax: {
+          inlineMath: [['$','$'], ['\\(','\\)']],
+          processEscapes: true
+        }
+      });
+    </script>
     <link rel="stylesheet" href="./css/common.css"/>
 
     <!-- highlightjs for code highlighting -->

--- a/src/string/suffix-array.md
+++ b/src/string/suffix-array.md
@@ -43,7 +43,7 @@ Sorting uses $O(n \log n)$ comparisons, and since comparing two strings will add
 Strictly speaking the following algorithm will not sort the suffixes, but rather the cyclic shifts of a string.
 However we can very easily derive an algorithm for sorting suffixes from it:
 it is enough to append an arbitrary character to the end of the string which is smaller than any character from the string.
-It is common to use the symbol $\\$$.
+It is common to use the symbol \$.
 Then the order of the sorted cyclic shifts is equivalent to the order of the sorted suffixes, as demonstrated here with the string $dabbb$.
 
 $$\begin{array}{lll}
@@ -122,15 +122,15 @@ To do this, note that the cyclic substrings of length $2^k$ consists of two subs
 Thus, for two substrings of length $2^k$ starting at position $i$ and $j$, all necessary information to compare them is contained in the pairs $(c[i],~ c[i + 2^{k-1}])$ and $(c[j],~ c[j + 2^{k-1}])$.
 $$\dots
 \overbrace{
-\underbrace{s_i \dots s_{i+2^{k-1}-1}}\_{\text{length} = 2^{k-1},~ \text{class} = c[i]}
+\underbrace{s_i \dots s_{i+2^{k-1}-1}}_{\text{length} = 2^{k-1},~ \text{class} = c[i]}
 \quad
-\underbrace{s_{i+2^{k-1}} \dots s_{i+2^k-1}}\_{\text{length} = 2^{k-1},~ \text{class} = c[i + 2^{k-1}]}
+\underbrace{s_{i+2^{k-1}} \dots s_{i+2^k-1}}_{\text{length} = 2^{k-1},~ \text{class} = c[i + 2^{k-1}]}
 }^{\text{length} = 2^k}
 \dots
 \overbrace{
-\underbrace{s_j \dots s_{j+2^{k-1}-1}}\_{\text{length} = 2^{k-1},~ \text{class} = c[j]}
+\underbrace{s_j \dots s_{j+2^{k-1}-1}}_{\text{length} = 2^{k-1},~ \text{class} = c[j]}
 \quad
-\underbrace{s_{j+2^{k-1}} \dots s_{j+2^k-1}}\_{\text{length} = 2^{k-1},~ \text{class} = c[j + 2^{k-1}]}
+\underbrace{s_{j+2^{k-1}} \dots s_{j+2^k-1}}_{\text{length} = 2^{k-1},~ \text{class} = c[j + 2^{k-1}]}
 }^{\text{length} = 2^k}
 \dots
 $$
@@ -240,14 +240,14 @@ We find the largest length of a block that is placed inside a substring of this 
 Then comparing the two substrings can be replaced by comparing two overlapping blocks of length $2^k$:
 first you need to compare the two blocks starting at $i$ and $j$, and if these are equal then compare the two blocks ending in positions $i + l - 1$ and $j + l - 1$:
 $$\dots
-\overbrace{\underbrace{s_i \dots s_{i+l-2^k} \dots s_{i+2^k-1}}\_{2^k} \dots s_{i+l-1}}^{\text{first}}
+\overbrace{\underbrace{s_i \dots s_{i+l-2^k} \dots s_{i+2^k-1}}_{2^k} \dots s_{i+l-1}}^{\text{first}}
 \dots
-\overbrace{\underbrace{s_j \dots s_{j+l-2^k} \dots s_{j+2^k-1}}\_{2^k} \dots s_{j+l-1}}^{\text{second}}
+\overbrace{\underbrace{s_j \dots s_{j+l-2^k} \dots s_{j+2^k-1}}_{2^k} \dots s_{j+l-1}}^{\text{second}}
 \dots$$
 $$\dots
-\overbrace{s_i \dots \underbrace{s_{i+l-2^k} \dots s_{i+2^k-1} \dots s_{i+l-1}}\_{2^k}}^{\text{first}}
+\overbrace{s_i \dots \underbrace{s_{i+l-2^k} \dots s_{i+2^k-1} \dots s_{i+l-1}}_{2^k}}^{\text{first}}
 \dots
-\overbrace{s_j \dots \underbrace{s_{j+l-2^k} \dots s_{j+2^k-1} \dots s_{j+l-1}}\_{2^k}}^{\text{second}}
+\overbrace{s_j \dots \underbrace{s_{j+l-2^k} \dots s_{j+2^k-1} \dots s_{j+l-1}}_{2^k}}^{\text{second}}
 \dots$$
 
 Here is the implementation of the comparison.


### PR DESCRIPTION
MathJax is having a hard time to convert `\\$`.  This change config MathJax to
process escape, and fix the usage of escaped dollar-sign in the document.

# Before
![before](https://user-images.githubusercontent.com/88476/130536336-9323747c-5c0e-4695-9c8e-7b3b67a3166f.png)

# After
![after](https://user-images.githubusercontent.com/88476/130536415-b23157ba-aac3-4a13-8178-2602c93e9f68.png)
