### PR TITLE
[Algebra][Fundamentals][Binary Exponentiation]: Fix typo in Binary exponentiation article

### DIFF
--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -66,7 +66,7 @@ long long binpow(long long a, long long b) {
 
 The second approach accomplishes the same task without recursion.
 It computes all the powers in a loop, and multiplies the ones with the corresponding set bit in $n$.
-Although the complexity of both approaches is identical, this approach will be faster in practice since we have the overhead of the recursive calls.
+Although the complexity of both approaches is identical, this approach will be faster in practice since we don't have the overhead of the recursive calls.
 
 ```cpp
 long long binpow(long long a, long long b) {


### PR DESCRIPTION
While giving information about why the iterative implementation is faster than the recursive one, the following was written:

"Although the complexity of both approaches is identical, this approach will be faster in practice since we have the overhead of the recursive calls."

However, it should be as follows:
"Although the complexity of both approaches is identical, this approach will be faster in practice since we **don't** have the overhead of the recursive calls."