### PR TITLE
Make some double-escaped curly braces single-escaped

### DIFF
--- a/src/algebra/factorization.md
+++ b/src/algebra/factorization.md
@@ -248,7 +248,7 @@ There is still one big open question.
 We don't know $p$ yet, so how can we argue about the sequence $\{x_i \bmod p\}$?
 
 It's actually quite easy.
-There is a cycle in the sequence $\\{x_i \bmod p\\}_{i \le j}$ if and only if there are two indices $s, t \le j$ and $t$ with $x_s \equiv x_t \bmod p$.
+There is a cycle in the sequence $\{x_i \bmod p\}_{i \le j}$ if and only if there are two indices $s, t \le j$ and $t$ with $x_s \equiv x_t \bmod p$.
 This equation can be rewritten as $x_s - x_t \equiv 0 \bmod p$ which is the same as $p ~|~ \gcd(x_s - x_t, n)$.
 
 Therefore, if we find two indices $s$ and $t$ with $g = \gcd(x_s - x_t, n) > 1$, we have found a cycle and also a factor $g$ of $n$.

--- a/src/combinatorics/inclusion-exclusion.md
+++ b/src/combinatorics/inclusion-exclusion.md
@@ -18,7 +18,7 @@ $$\left| \bigcup_{i=1}^n A_i \right| = \sum_{i=1}^n|A_i| - \sum_{1\leq i<j\leq n
 
 And in a more compact way:
 
-$$\left|\bigcup_{i=1}^n A_i \right| = \sum_{\emptyset \neq J\subseteq \\{1,2,\ldots ,n\\}} (-1)^{|J|-1}{\Biggl |}\bigcap_{j\in J}A_{j}{\Biggr |}$$
+$$\left|\bigcup_{i=1}^n A_i \right| = \sum_{\emptyset \neq J\subseteq \{1,2,\ldots ,n\}} (-1)^{|J|-1}{\Biggl |}\bigcap_{j\in J}A_{j}{\Biggr |}$$
 
 ### The formulation using Venn diagrams
 
@@ -43,13 +43,13 @@ $$\begin{eqnarray}
 
 And in a more compact way:
 
-$${\cal P} \left(\bigcup_{i=1}^n A_i \right) = \sum_{\emptyset \neq J\subseteq \\{1,2,\ldots ,n\\}} (-1)^{|J|-1}\ {\cal P}{\Biggl (}\bigcap_{j\in J}A_{j}{\Biggr )}$$
+$${\cal P} \left(\bigcup_{i=1}^n A_i \right) = \sum_{\emptyset \neq J\subseteq \{1,2,\ldots ,n\}} (-1)^{|J|-1}\ {\cal P}{\Biggl (}\bigcap_{j\in J}A_{j}{\Biggr )}$$
 
 ## Proof
 
 For the proof it is convenient to use the mathematical formulation in terms of set theory:
 
-$$\left|\bigcup_{i=1}^n A_i \right| = \sum_{\emptyset \neq J\subseteq \\{1,2,\ldots ,n\\}} (-1)^{|J|-1}{\Biggl |}\bigcap_{j\in J}A_{j}{\Biggr |}$$
+$$\left|\bigcup_{i=1}^n A_i \right| = \sum_{\emptyset \neq J\subseteq \{1,2,\ldots ,n\}} (-1)^{|J|-1}{\Biggl |}\bigcap_{j\in J}A_{j}{\Biggr |}$$
 
 We want to prove that any element contained in at least one of the sets $A_i$ will occur in the formula only once (note that elements which are not present in any of the sets $A_i$ will never be considered on the right part of the formula).
 

--- a/src/game_theory/sprague-grundy-nim.md
+++ b/src/game_theory/sprague-grundy-nim.md
@@ -113,7 +113,7 @@ Since the game is acyclic, sooner or later the current player won't be able to u
 
 ### Sprague-Grundy theorem
 
-Let's consider a state $v$ of a two-player impartial game and let $v_i$ be the states reachable from it (where $i \in \\{ 1, 2, \dots, k \\} , k \ge 0$).
+Let's consider a state $v$ of a two-player impartial game and let $v_i$ be the states reachable from it (where $i \in \{ 1, 2, \dots, k \} , k \ge 0$).
 To this state, we can assign a fully equivalent game of Nim with one pile of size $x$.
 The number $x$ is called the Grundy value or nim-value of state $v$.
 
@@ -135,7 +135,7 @@ That is correct, since an empty Nim is losing.
 Now consider any other vertex $v$.
 By induction, we assume the values $x_i$ corresponding to its reachable vertices are already calculated.
 
-Let $p = \text{mex}\ \\{ x_1, \ldots, x_k \\}$.
+Let $p = \text{mex}\ \{ x_1, \ldots, x_k \}$.
 Then we know that for any integer $i \in [0, p)$ there exists a reachable vertex with Grundy value $i$.
 This means $v$ is **equivalent to a state of the game of Nim with increases with one pile of size $p$**.
 In such a game we have transitions to piles of every size smaller than $p$ and possibly transitions to piles with sizes greater than $p$.
@@ -188,7 +188,7 @@ For the edge case of the cross being marked on position $1$ or $n$, we go to the
 
 Thus, the Grundy value $g(n)$ has the form:
 
-$$g(n) = \text{mex} \Bigl( \\{ g(n-2) \\} \cup \\{g(i-2) \oplus g(n-i-1) \mid 2 \leq i \leq n-1\\} \Bigr) .$$
+$$g(n) = \text{mex} \Bigl( \{ g(n-2) \} \cup \{g(i-2) \oplus g(n-i-1) \mid 2 \leq i \leq n-1\} \Bigr) .$$
 
 So we've got a $O(n^2)$ solution.
 

--- a/src/geometry/delaunay.md
+++ b/src/geometry/delaunay.md
@@ -1,9 +1,9 @@
 # Delaunay triangulation and Voronoi diagram
 
-Consider a set $\\{p_i\\}$ of points on the plane.
-A **Voronoi diagram** $V(\\{p_i\\})$ of $\\{p_i\\}$ is a partition of the plane into $n$ regions $V_i$, where $V_i = \\{p\in\mathbb{R}^2;\ \rho(p, p_i) = \min\ \rho(p, p_k)\\}$.
+Consider a set $\{p_i\}$ of points on the plane.
+A **Voronoi diagram** $V(\{p_i\})$ of $\{p_i\}$ is a partition of the plane into $n$ regions $V_i$, where $V_i = \{p\in\mathbb{R}^2;\ \rho(p, p_i) = \min\ \rho(p, p_k)\}$.
 The cells of the Voronoi diagram are polygons (possibly infinite).
-A **Delaunay triangulation** $D(\\{p_i\\})$ of $\\{p_i\\}$ is a triangulation where every point $p_i$ is outside or on the boundary of the circumcircle of each triangle $T \in D(\\{p_i\\})$.
+A **Delaunay triangulation** $D(\{p_i\})$ of $\{p_i\}$ is a triangulation where every point $p_i$ is outside or on the boundary of the circumcircle of each triangle $T \in D(\{p_i\})$.
 
 There is a nasty degenerated case when the Voronoi diagram isn't connected and Delaunay triangulation doesn't exist. This case is when all points are collinear.
 
@@ -15,11 +15,11 @@ The Minimum Euclidean spanning tree of a point set is a subset of edges of its' 
 
 ## Duality
 
-Suppose that $\\{p_i\\}$ is not collinear and among $\\{p_i\\}$ no four points lie on one circle. Then $V(\\{p_i\\})$ and $D(\\{p_i\\})$ are dual, so if we obtain one of them, we may obtain the other in $O(n)$. What to do if it's not the case? The collinear case may be processed easily. Otherwise, $V$ and $D'$ are dual, where $D'$ is obtained from $D$ by removing all the edges such that two triangles on this edge share the circumcircle.
+Suppose that $\{p_i\}$ is not collinear and among $\{p_i\}$ no four points lie on one circle. Then $V(\{p_i\})$ and $D(\{p_i\})$ are dual, so if we obtain one of them, we may obtain the other in $O(n)$. What to do if it's not the case? The collinear case may be processed easily. Otherwise, $V$ and $D'$ are dual, where $D'$ is obtained from $D$ by removing all the edges such that two triangles on this edge share the circumcircle.
 
 ## Building Delaunay and Voronoi
 
-Because of the duality, we only need a fast algorithm to compute only one of $V$ and $D$. We will describe how to build $D(\\{p_i\\})$ in $O(n\log n)$. The triangulation will be built via divide-and-conquer algorithm due to Guibas and Stolfi.
+Because of the duality, we only need a fast algorithm to compute only one of $V$ and $D$. We will describe how to build $D(\{p_i\})$ in $O(n\log n)$. The triangulation will be built via divide-and-conquer algorithm due to Guibas and Stolfi.
 
 ## Quad-edge data structure
 

--- a/src/geometry/halfplane-intersection.md
+++ b/src/geometry/halfplane-intersection.md
@@ -45,11 +45,11 @@ To better visualize this fact, suppose we're performing the incremental approach
 
 Here's a small example with an illustration:
 
-Let $H = \\{ A, B, C, D, E \\}$ be the set of half-planes currently present in the intersection. Additionally, let $P = \\{ p, q, r, s \\}$ be the set of intersection points of adjacent half-planes in H. Now, suppose we wish to intersect it with the half-plane $F$, as seen in the illustration below:
+Let $H = \{ A, B, C, D, E \}$ be the set of half-planes currently present in the intersection. Additionally, let $P = \{ p, q, r, s \}$ be the set of intersection points of adjacent half-planes in H. Now, suppose we wish to intersect it with the half-plane $F$, as seen in the illustration below:
 
 ![](halfplanes_hp1.png)
 
-Notice the half-plane $F$ makes $A$ and $E$ redundant in the intersection. So we remove both $A$ and $E$ from the front and back of the intersection, respectively, and add $F$ at the end. And we finally obtain the new intersection $H = \\{ B, C, D, F\\}$ with $P = \\{ q, r, t, u \\}$.
+Notice the half-plane $F$ makes $A$ and $E$ redundant in the intersection. So we remove both $A$ and $E$ from the front and back of the intersection, respectively, and add $F$ at the end. And we finally obtain the new intersection $H = \{ B, C, D, F\}$ with $P = \{ q, r, t, u \}$.
 
 ![](halfplanes_hp2.png)
 

--- a/src/geometry/minkowski.md
+++ b/src/geometry/minkowski.md
@@ -1,7 +1,7 @@
 # Minkowski sum of convex polygons
 
 ## Definition
-Consider two sets $A$ and $B$ of points on a plane. Minkowski sum $A + B$ is defined as $\\{a + b| a \in A, b \in B\\}$.
+Consider two sets $A$ and $B$ of points on a plane. Minkowski sum $A + B$ is defined as $\{a + b| a \in A, b \in B\}$.
 Here we will consider the case when $A$ and $B$ consist of convex polygons $P$ and $Q$ with their interiors.
 Throughout this article we will identify polygons with ordered sequences of their vertices, so that notation like $|P|$ or
 $P_i$ makes sense.
@@ -12,8 +12,8 @@ It turns out that the sum of convex polygons $P$ and $Q$ is a convex polygon wit
 Here we consider the polygons to be cyclically enumerated, i. e. $P_{|P|} = P_0,\ Q_{|Q|} = Q_0$ and so on.
 
 Since the size of the sum is linear in terms of the sizes of initial polygons, we should aim at finding a linear-time algorithm.
-Suppose that both polygons are ordered counter-clockwise. Consider sequences of edges $\\{\overrightarrow{P_iP_{i+1}}\\}$
-and $\\{\overrightarrow{Q_jQ_{j+1}}\\}$ ordered by polar angle. We claim that the sequence of edges of $P + Q$ can be obtained by merging
+Suppose that both polygons are ordered counter-clockwise. Consider sequences of edges $\{\overrightarrow{P_iP_{i+1}}\}$
+and $\{\overrightarrow{Q_jQ_{j+1}}\}$ ordered by polar angle. We claim that the sequence of edges of $P + Q$ can be obtained by merging
 these two sequences preserving polar angle order and replacing consequitive co-directed vectors with their sum. Straightforward usage of this idea results
 in a linear-time algorithm, however, restoring the vertices of $P + Q$ from the sequence of sides requires repeated addition of vectors,
 which may introduce unwanted precision issues if we're working with floating-point coordinates, so we will describe a slight

--- a/src/graph/all-pair-shortest-path-floyd-warshall.md
+++ b/src/graph/all-pair-shortest-path-floyd-warshall.md
@@ -22,7 +22,7 @@ The key idea of the algorithm is to partition the process of finding the shortes
 Let us number the vertices starting from 1 to $n$.
 The matrix of distances is $d[ ][ ]$.
 
-Before $k$-th phase ($k = 1 \dots n$), $d[i][j]$ for any vertices $i$ and $j$ stores the length of the shortest path between the vertex $i$ and vertex $j$, which contains only the vertices $\\{1, 2, ..., k-1\\}$ as internal vertices in the path.
+Before $k$-th phase ($k = 1 \dots n$), $d[i][j]$ for any vertices $i$ and $j$ stores the length of the shortest path between the vertex $i$ and vertex $j$, which contains only the vertices $\{1, 2, ..., k-1\}$ as internal vertices in the path.
 
 In other words, before $k$-th phase the value of $d[i][j]$ is equal to the length of the shortest path from vertex $i$ to the vertex $j$, if this path is allowed to enter only the vertex with numbers smaller than $k$ (the beginning and end of the path are not restricted by this property).
 
@@ -34,16 +34,16 @@ Suppose now that we are in the $k$-th phase, and we want to compute the matrix $
 We have to fix the distances for some vertices pairs $(i, j)$.
 There are two fundamentally different cases:
 
-*   The shortest way from the vertex $i$ to the vertex $j$ with internal vertices from the set $\\{1, 2, \dots, k\\}$ coincides with the shortest path with internal vertices from the set $\\{1, 2, \dots, k-1\\}$.
+*   The shortest way from the vertex $i$ to the vertex $j$ with internal vertices from the set $\{1, 2, \dots, k\}$ coincides with the shortest path with internal vertices from the set $\{1, 2, \dots, k-1\}$.
 
     In this case, $d[i][j]$ will not change during the transition.
 
-*   The shortest path with internal vertices from $\\{1, 2, \dots, k\\}$ is shorter.
+*   The shortest path with internal vertices from $\{1, 2, \dots, k\}$ is shorter.
 
     This means that the new, shorter path passes through the vertex $k$.
     This means that we can split the shortest path between $i$ and $j$ into two paths:
     the path between $i$ and $k$, and the path between $k$ and $j$.
-    It is clear that both this paths only use internal vertices of $\\{1, 2, \dots, k-1\\}$ and are the shortest such paths in that respect.
+    It is clear that both this paths only use internal vertices of $\{1, 2, \dots, k-1\}$ and are the shortest such paths in that respect.
     Therefore we already have computed the lengths of those paths before, and we can compute the length of the shortest path between $i$ and $j$ as $d[i][k] + d[k][j]$.
 
 Combining these two cases we find that we can recalculate the length of all pairs $(i, j)$ in the $k$-th phase in the following way:

--- a/src/graph/edmonds_karp.md
+++ b/src/graph/edmonds_karp.md
@@ -192,8 +192,8 @@ The max-flow min-cut theorem goes even further.
 It says that the capacity of the maximum flow has to be equal to the capacity of the minimum cut.
 
 In the following image you can see the minimum cut of the flow network we used earlier.
-It shows that the capacity of the cut $\\{s, A, D\\}$ and $\\{B, C, t\\}$ is $5 + 3 + 2 = 10$, which is equal to the maximum flow that we found.
-Other cuts will have a bigger capacity, like the capacity between $\\{s, A\\}$ and $\\{B, C, D, t\\}$ is $4 + 3 + 5 = 12$.
+It shows that the capacity of the cut $\{s, A, D\}$ and $\{B, C, t\}$ is $5 + 3 + 2 = 10$, which is equal to the maximum flow that we found.
+Other cuts will have a bigger capacity, like the capacity between $\{s, A\}$ and $\{B, C, D, t\}$ is $4 + 3 + 5 = 12$.
 <center>![Minimum cut](Cut.png)</center>
 
 A minimum cut can be found after performing a maximum flow computation using the Ford-Fulkerson method.

--- a/src/graph/mpm.md
+++ b/src/graph/mpm.md
@@ -16,7 +16,7 @@ p_{out}(v) &= \sum\limits_{(v, u)\in L}(c(v, u) - f(v, u))
 
 Also we set $p_{in}(s) = p_{out}(t) = \infty$.
 Given $p_{in}$ and $p_{out}$ we define the _potential_ as $p(v) = min(p_{in}(v), p_{out}(v))$.
-We call a node $r$ a _reference node_ if $p(r) = min\\{p(v)\\}$.
+We call a node $r$ a _reference node_ if $p(r) = min\{p(v)\}$.
 Consider a reference node $r$.
 We claim that the flow can be increased by $p(r)$ in such a way that $p(r)$ becomes $0$.
 It is true because $L$ is acyclic, so we can push the flow out of $r$ by outgoing edges and it will reach $t$ because each node has enough outer potential to push the flow out when it reaches it.

--- a/src/graph/second_best_mst.md
+++ b/src/graph/second_best_mst.md
@@ -8,7 +8,7 @@ A second best MST $T'$ is a spanning tree, that has the second minimum weight su
 Let $T$ be the Minimum Spanning Tree of a graph $G$.
 It can be observed, that the second best Minimum Spanning Tree differs from $T$ by only one edge replacement. (For a proof of this statement refer to problem 23-1 [here](http://www-bcf.usc.edu/~shanghua/teaching/Spring2010/public_html/files/HW2_Solutions_A.pdf)).
 
-So we need to find an edge $e_{new}$ which is in not in $T$, and replace it with an edge in $T$ (let it be $e_{old}$) such that the new graph $T' = (T \cup \\{e_{new}\\}) \setminus \\{e_{old}\\}$ is a spanning tree and the weight difference ($e_{new} - e_{old}$) is minimum.
+So we need to find an edge $e_{new}$ which is in not in $T$, and replace it with an edge in $T$ (let it be $e_{old}$) such that the new graph $T' = (T \cup \{e_{new}\}) \setminus \{e_{old}\}$ is a spanning tree and the weight difference ($e_{new} - e_{old}$) is minimum.
 
 
 ## Using Kruskal's Algorithm

--- a/src/string/aho_corasick.md
+++ b/src/string/aho_corasick.md
@@ -181,7 +181,7 @@ How can we find out for a state $v$, if there are any matches with strings for t
 First, it is clear that if we stand on a $\text{leaf}$ vertex, then the string corresponding to the vertex ends at this position in the text.
 However this is by no means the only possible case of achieving a match:
 if we can reach one or more  $\text{leaf}$ vertices by moving along the suffix links, then there will be also a match corresponding to each found $\text{leaf}$ vertex.
-A simple example demonstrating this situation can be creating using the set of strings $\\{dabce, abc, bc\\}$ and the text $dabc$.
+A simple example demonstrating this situation can be creating using the set of strings $\{dabce, abc, bc\}$ and the text $dabc$.
 
 Thus if we store in each $\text{leaf}$ vertex the index of the string corresponding to it (or the list of indices if duplicate strings appear in the set), then we can find in $O(n)$ time the indices of all strings which match the current state, by simply following the suffix links from the current vertex to the root.
 However this is not the most efficient solution, since this gives us $O(n ~ \text{len})$ complexity in total.

--- a/src/string/prefix-function.md
+++ b/src/string/prefix-function.md
@@ -9,7 +9,7 @@ By definition, $\pi[0] = 0$.
 
 Mathematically the definition of the prefix function can be written as follows:
 
-$$\pi[i] = \max_ {k = 0 \dots i} \\{k : s[0 \dots k-1] = s[i-(k-1) \dots i] \\}$$
+$$\pi[i] = \max_ {k = 0 \dots i} \{k : s[0 \dots k-1] = s[i-(k-1) \dots i] \}$$
 
 For example, prefix function of string "abcabcd" is $[0, 0, 0, 1, 2, 3, 0]$, and prefix function of string "aabaaab" is $[0, 1, 0, 1, 2, 2, 3]$.
 

--- a/src/string/suffix-automaton.md
+++ b/src/string/suffix-automaton.md
@@ -149,7 +149,7 @@ We denote by $t$ the biggest such suffix, and make a suffix link to it.
 
 In other words, a **suffix link** $link(v)$ leads to the state that corresponds to the **longest suffix** of $w$ that is in another $endpos$-equivalence class.
 
-Here we assume that the initial state $t_0$ corresponds to its own equivalence class (containing only the empty string), and for convenience we set $endpos(t_0) = \\{-1, 0, \dots, length(s)-1\\}$.
+Here we assume that the initial state $t_0$ corresponds to its own equivalence class (containing only the empty string), and for convenience we set $endpos(t_0) = \{-1, 0, \dots, length(s)-1\}$.
 
 **Lemma 4**:
 Suffix links form a **tree** with the root $t_0$.


### PR DESCRIPTION
This is the same thing as
https://github.com/e-maxx-eng/e-maxx-eng/pull/801
I searched for all instances of `\\{` and changed all but one.
There is an instance in the D&C DP chapter that I think looks better without the curly braces.