### PR TITLE
fix: Upper bound of index in 1-Based Fenwick Tree

### DIFF
--- a/src/data_structures/fenwick.md
+++ b/src/data_structures/fenwick.md
@@ -301,7 +301,7 @@ struct FenwickTreeOneBasedIndexing {
     }
 
     void add(int idx, int delta) {
-        for (++idx; idx < n; idx += idx & -idx)
+        for (++idx; idx <= n; idx += idx & -idx)
             bit[idx] += delta;
     }
 };
@@ -337,7 +337,7 @@ The following implementation uses one-based indexing.
 
 ```cpp
 void add(int idx, int val) {
-    for (++idx; idx < n; idx += idx & -idx)
+    for (++idx; idx <= n; idx += idx & -idx)
         bit[idx] += val;
 }
 


### PR DESCRIPTION
In 1-Based Indexing Fenwick Tree, We should go from 0 < i <= N.
but in implementation its 0 < i < N.