### PR TITLE
Added MCBM practice problems and vertex cover note

### DIFF
--- a/src/graph/kuhn_maximum_bipartite_matching.md
+++ b/src/graph/kuhn_maximum_bipartite_matching.md
@@ -214,3 +214,9 @@ there is a test case against it, on which it will find a matching that is much s
 * Kuhn's algorithm is a subroutine in the **Hungarian algorithm**, also known as the **Kuhn-Munkres algorithm**.
 * Kuhn's algorithm runs in $O(nm)$ time. It is generally simple to implement, however, more efficient algorithms exist for the maximum bipartite matching problem - such as the 
     **Hopcroft-Karp-Karzanov algorithm**, which runs in $O(\sqrt{n}m)$ time.
+* The [minimum vertex cover problem](https://en.wikipedia.org/wiki/Vertex_cover) is NP-hard for general graphs.  However, [Kőnig's theorem](https://en.wikipedia.org/wiki/K%C5%91nig%27s_theorem_(graph_theory)) gives that, for bipartite graphs, the cardinality of the maximum matching equals the cardinality of the minimum vertex cover.  Hence, we can use maximum bipartite matching algorithms to solve the minimum vertex cover problem in polynomial time for bipartite graphs.
+
+## Practice Problems
+
+* [Kattis - Gopher II](https://open.kattis.com/problems/gopher2)
+* [Kattis - Borders](https://open.kattis.com/problems/borders)


### PR DESCRIPTION
Added a note about using MCBM algorithms to find the cardinality of the minimum vertex cover for bipartite graphs (Kőnig's theorem).  Also added two practice problems from Kattis.