### PR TITLE
Fixing assignment of variables "l" and "r"

### DIFF
--- a/src/string/manacher.md
+++ b/src/string/manacher.md
@@ -142,7 +142,7 @@ vector<int> manacher_odd(string s) {
     int n = s.size();
     s = "$" + s + "^";
     vector<int> p(n + 2);
-    int l = 0, r = -1;
+    int l = 1, r = 1;
     for(int i = 1; i <= n; i++) {
         p[i] = max(0, min(r - i, p[l + (r - i)]));
         while(s[i - p[i]] == s[i + p[i]]) {


### PR DESCRIPTION
The previous assignment of the "l" and "r" variables lead to out of bounds access of array p, which is cancelled out by subsequent operations, but still triggers undefined behavior