### PR TITLE
Typo in euler_path.md

### DIFF
--- a/src/graph/euler_path.md
+++ b/src/graph/euler_path.md
@@ -47,7 +47,7 @@ until St is empty
     put the second end of this edge in St;
 ```
 
-It is easy to check the equivalence of these two forms of the algorithm. However, the second form is obviously faster, and the code will be much more.
+It is easy to check the equivalence of these two forms of the algorithm. However, the second form is obviously faster, and the code will be much more efficient.
 
 ## The Domino problem
 


### PR DESCRIPTION
Word 'efficient' missing in line 50 of [euler_path.md](https://github.com/e-maxx-eng/e-maxx-eng/blob/master/src/graph/euler_path.md)