### PR TITLE
Enable tags to track article meta information

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build pages
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.PAT_API_KEY }}
+          MKDOCS_ENABLE_GIT_REVISION_DATE: True
         run: |
           mkdocs build --strict
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Build pages
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.PAT_API_KEY }}
+          MKDOCS_ENABLE_GIT_REVISION_DATE: True
         run: |
           mkdocs build --strict
       - name: Run algorithm code tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,21 +46,25 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji 
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - meta
 
 plugins:
   - mkdocs-simple-hooks:
       hooks:
           on_env: "hooks:on_env"
   - search
+  - tags:
+      tags_file: tags.md
   - literate-nav:
       nav_file: navigation.md
   - git-revision-date-localized:
       enable_creation_date: true
+      enabled: !ENV [MKDOCS_ENABLE_GIT_REVISION_DATE, False]
   - git-authors
   - git-committers:
       repository: e-maxx-eng/e-maxx-eng
       docs_path: src/
-      token: !!python/object/apply:os.getenv ["MKDOCS_GIT_COMMITTERS_APIKEY"]
+      token: !ENV MKDOCS_GIT_COMMITTERS_APIKEY
   - macros
 
 extra:

--- a/src/algebra/all-submasks.md
+++ b/src/algebra/all-submasks.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: all_submasks
 ---
 
 # Submask Enumeration

--- a/src/algebra/all-submasks.md
+++ b/src/algebra/all-submasks.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Submask Enumeration
 
 ## Enumerating all submasks of a given mask

--- a/src/algebra/balanced-ternary.md
+++ b/src/algebra/balanced-ternary.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: balanced_ternary
 ---
 
 # Balanced Ternary

--- a/src/algebra/balanced-ternary.md
+++ b/src/algebra/balanced-ternary.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Balanced Ternary
 
 !["Setun computer using Balanced Ternary system"](http://ternary.3neko.ru/photo/setun1_small.jpg)

--- a/src/algebra/big-integer.md
+++ b/src/algebra/big-integer.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: big_integer
 ---
 
 # Arbitrary-Precision Arithmetic

--- a/src/algebra/big-integer.md
+++ b/src/algebra/big-integer.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Arbitrary-Precision Arithmetic
 
 Arbitrary-Precision arithmetic, also known as "bignum" or simply "long arithmetic" is a set of data structures and algorithms which allows to process much greater numbers than can be fit in standard data types. Here are several types of arbitrary-precision arithmetic.

--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: binary_exp
 ---
 
 # Binary Exponentiation

--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: binary_exp
+e_maxx_link: binary_pow
 ---
 
 # Binary Exponentiation

--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Binary Exponentiation
 
 Binary exponentiation (also known as exponentiation by squaring) is a trick which allows to calculate $a^n$ using only $O(\log n)$ multiplications (instead of $O(n)$ multiplications required by the naive approach).

--- a/src/algebra/chinese-remainder-theorem.md
+++ b/src/algebra/chinese-remainder-theorem.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: chinese_remainder_theorem
+e_maxx_link: chinese_theorem
 ---
 
 # Chinese Remainder Theorem

--- a/src/algebra/chinese-remainder-theorem.md
+++ b/src/algebra/chinese-remainder-theorem.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Chinese Remainder Theorem
 
 The Chinese Remainder Theorem (which will be referred to as CRT in the rest of this article) was discovered by Chinese mathematician Sun Zi.

--- a/src/algebra/chinese-remainder-theorem.md
+++ b/src/algebra/chinese-remainder-theorem.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: chinese_remainder_theorem
 ---
 
 # Chinese Remainder Theorem

--- a/src/algebra/continued-fractions.md
+++ b/src/algebra/continued-fractions.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Original
+  - "Author: adamant"
+---
+
 <!--?title Continued fractions -->
 # Continued fractions
 

--- a/src/algebra/continued-fractions.md
+++ b/src/algebra/continued-fractions.md
@@ -1,7 +1,6 @@
 ---
 tags:
   - Original
-  - "Author: adamant"
 ---
 
 <!--?title Continued fractions -->

--- a/src/algebra/discrete-log.md
+++ b/src/algebra/discrete-log.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Discrete Logarithm
 
 The discrete logarithm is an integer $x$ satisfying the equation

--- a/src/algebra/discrete-log.md
+++ b/src/algebra/discrete-log.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: discrete_log
 ---
 
 # Discrete Logarithm

--- a/src/algebra/discrete-root.md
+++ b/src/algebra/discrete-root.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Discrete Root
 
 The problem of finding a discrete root is defined as follows. Given a prime $n$ and two integers $a$ and $k$, find all $x$ for which:

--- a/src/algebra/discrete-root.md
+++ b/src/algebra/discrete-root.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: discrete_root
 ---
 
 # Discrete Root

--- a/src/algebra/divisors.md
+++ b/src/algebra/divisors.md
@@ -1,7 +1,6 @@
 ---
 tags:
   - Original
-  - "Author: jakobkogler"
 ---
 
 # Number of divisors / sum of divisors

--- a/src/algebra/divisors.md
+++ b/src/algebra/divisors.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Original
+  - "Author: jakobkogler"
+---
+
 # Number of divisors / sum of divisors
 
 In this article we discuss how to compute the number of divisors $d(n)$ and the sum of divisors $\sigma(n)$ of a given number $n$.

--- a/src/algebra/euclid-algorithm.md
+++ b/src/algebra/euclid-algorithm.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: euclid_algorithm
 ---
 
 # Euclidean algorithm for computing the greatest common divisor

--- a/src/algebra/euclid-algorithm.md
+++ b/src/algebra/euclid-algorithm.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Euclidean algorithm for computing the greatest common divisor
 
 Given two non-negative integers $a$ and $b$, we have to find their **GCD** (greatest common divisor), i.e. the largest number which is a divisor of both $a$ and $b$.

--- a/src/algebra/extended-euclid-algorithm.md
+++ b/src/algebra/extended-euclid-algorithm.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Extended Euclidean Algorithm
 
 While the [Euclidean algorithm](euclid-algorithm.md) calculates only the greatest common divisor (GCD) of two integers $a$ and $b$, the extended version also finds a way to represent GCD in terms of $a$ and $b$, i.e. coefficients $x$ and $y$ for which:

--- a/src/algebra/extended-euclid-algorithm.md
+++ b/src/algebra/extended-euclid-algorithm.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: extended_euclid_algorithm
 ---
 
 # Extended Euclidean Algorithm

--- a/src/algebra/factorial-divisors.md
+++ b/src/algebra/factorial-divisors.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Finding Power of Factorial Divisor
 
 You are given two numbers $n$ and $k$. Find the largest power of $k$ $x$ such that $n!$ is divisible by $k^x$.

--- a/src/algebra/factorial-divisors.md
+++ b/src/algebra/factorial-divisors.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: factorial_divisors
 ---
 
 # Finding Power of Factorial Divisor

--- a/src/algebra/factorial-modulo.md
+++ b/src/algebra/factorial-modulo.md
@@ -1,3 +1,10 @@
+<!-- Original link: modular_factorial -->
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 ---
 title: Factorial modulo p 
 ---

--- a/src/algebra/factorial-modulo.md
+++ b/src/algebra/factorial-modulo.md
@@ -1,4 +1,5 @@
 ---
+title: Factorial modulo p
 tags:
   - Translated
 e_maxx_link: modular_factorial

--- a/src/algebra/factorial-modulo.md
+++ b/src/algebra/factorial-modulo.md
@@ -5,9 +5,6 @@ tags:
 e_maxx_link: modular_factorial
 ---
 
----
-title: Factorial modulo p 
----
 # Factorial modulo $p$
 
 In some cases it is necessary to consider complex formulas modulo some prime $p$, containing factorials in both numerator and denominator, like such that you encounter in the formula for Binomial coefficients.

--- a/src/algebra/factorial-modulo.md
+++ b/src/algebra/factorial-modulo.md
@@ -1,8 +1,7 @@
-<!-- Original link: modular_factorial -->
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: modular_factorial
 ---
 
 ---

--- a/src/algebra/factoring-exp.md
+++ b/src/algebra/factoring-exp.md
@@ -1,8 +1,6 @@
 ---
 tags:
   - Original
-  - "Author: hselasky"
-  - "Contributor: adamant"
 ---
 
 # Binary Exponentiation by Factoring

--- a/src/algebra/factoring-exp.md
+++ b/src/algebra/factoring-exp.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - Original
+  - "Author: hselasky"
+  - "Contributor: adamant"
+---
+
 # Binary Exponentiation by Factoring
 
 Consider a problem of computing $ax^y \pmod{2^d}$, given integers $a$, $x$, $y$ and $d \geq 3$, where $x$ is odd.

--- a/src/algebra/factorization.md
+++ b/src/algebra/factorization.md
@@ -1,7 +1,7 @@
 ---
 tags:
-  - Translated
-  - "From: e-maxx.ru"
+  - Original
+  - "Author: jakobkogler"
 ---
 
 # Integer factorization

--- a/src/algebra/factorization.md
+++ b/src/algebra/factorization.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Integer factorization
 
 In this article we list several algorithms for factorizing integers, each of them can be both fast and also slow (some slower than others) depending on their input.

--- a/src/algebra/factorization.md
+++ b/src/algebra/factorization.md
@@ -1,7 +1,6 @@
 ---
 tags:
   - Original
-  - "Author: jakobkogler"
 ---
 
 # Integer factorization

--- a/src/algebra/fft.md
+++ b/src/algebra/fft.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: fft
+e_maxx_link: fft_multiply
 ---
 
 # Fast Fourier transform

--- a/src/algebra/fft.md
+++ b/src/algebra/fft.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Fast Fourier transform
 
 In this article we will discuss an algorithm that allows us to multiply two polynomials of length $n$ in $O(n \log n)$ time, which is better than the trivial multiplication which takes $O(n^2)$ time.

--- a/src/algebra/fft.md
+++ b/src/algebra/fft.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: fft
 ---
 
 # Fast Fourier transform

--- a/src/algebra/fibonacci-numbers.md
+++ b/src/algebra/fibonacci-numbers.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Fibonacci Numbers
 
 The Fibonacci sequence is defined as follows:

--- a/src/algebra/fibonacci-numbers.md
+++ b/src/algebra/fibonacci-numbers.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: fibonacci_numbers
 ---
 
 # Fibonacci Numbers

--- a/src/algebra/gray-code.md
+++ b/src/algebra/gray-code.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: gray_code
 ---
 
 # Gray code

--- a/src/algebra/gray-code.md
+++ b/src/algebra/gray-code.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Gray code
 
 Gray code is a binary numeral system where two successive values differ in only one bit. 

--- a/src/algebra/linear-diophantine-equation.md
+++ b/src/algebra/linear-diophantine-equation.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: linear_diophantine_equation
 ---
 
 # Linear Diophantine Equation

--- a/src/algebra/linear-diophantine-equation.md
+++ b/src/algebra/linear-diophantine-equation.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: linear_diophantine_equation
+e_maxx_link: diofant_2_equation
 ---
 
 # Linear Diophantine Equation

--- a/src/algebra/linear-diophantine-equation.md
+++ b/src/algebra/linear-diophantine-equation.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Linear Diophantine Equation
 
 A Linear Diophantine Equation (in two variables) is an equation of the general form:

--- a/src/algebra/linear_congruence_equation.md
+++ b/src/algebra/linear_congruence_equation.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: linear_congruence_equation
+e_maxx_link: diofant_1_equation
 ---
 
 # Linear Congruence Equation

--- a/src/algebra/linear_congruence_equation.md
+++ b/src/algebra/linear_congruence_equation.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: linear_congruence_equation
+---
+
 # Linear Congruence Equation
 
 This equation is of the form:

--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: module_inverse
 ---
 
 # Modular Multiplicative Inverse

--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: module_inverse
+e_maxx_link: reverse_element
 ---
 
 # Modular Multiplicative Inverse

--- a/src/algebra/module-inverse.md
+++ b/src/algebra/module-inverse.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Modular Multiplicative Inverse
 
 ## Definition

--- a/src/algebra/montgomery_multiplication.md
+++ b/src/algebra/montgomery_multiplication.md
@@ -1,7 +1,6 @@
 ---
 tags:
   - Original
-  - 'Author: jakobkogler'
 ---
 
 # Montgomery Multiplication

--- a/src/algebra/montgomery_multiplication.md
+++ b/src/algebra/montgomery_multiplication.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Original
+  - 'Author: jakobkogler'
+---
+
 # Montgomery Multiplication
 
 Many algorithms in number theory, like [prime testing](primality_tests.md) or [integer factorization](factorization.md), and in cryptography, like RSA, require lots of operations modulo a large number.

--- a/src/algebra/phi-function.md
+++ b/src/algebra/phi-function.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: phi_function
+e_maxx_link: euler_function
 ---
 
 # Euler's totient function

--- a/src/algebra/phi-function.md
+++ b/src/algebra/phi-function.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Euler's totient function
 
 Euler's totient function, also known as **phi-function** $\phi (n)$, counts the number of integers between 1 and $n$ inclusive, which are coprime to $n$. Two numbers are coprime if their greatest common divisor equals $1$ ($1$ is considered to be coprime to any number).

--- a/src/algebra/phi-function.md
+++ b/src/algebra/phi-function.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: phi_function
 ---
 
 # Euler's totient function

--- a/src/algebra/polynomial.md
+++ b/src/algebra/polynomial.md
@@ -1,7 +1,6 @@
 ---
 tags:
   - Original
-  - "Author: adamant"
 ---
 
 # Operations on polynomials and series

--- a/src/algebra/polynomial.md
+++ b/src/algebra/polynomial.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - Translated
+  - Original
   - "Author: adamant"
 ---
 

--- a/src/algebra/polynomial.md
+++ b/src/algebra/polynomial.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "Author: adamant"
+---
+
 # Operations on polynomials and series
 
 In this article we will cover common operations that you will probably have to do if you deal with polynomials.

--- a/src/algebra/primality_tests.md
+++ b/src/algebra/primality_tests.md
@@ -1,7 +1,6 @@
 ---
 tags:
     - Original
-    - 'Author: jakobkogler'
 ---
 
 # Primality tests

--- a/src/algebra/primality_tests.md
+++ b/src/algebra/primality_tests.md
@@ -1,3 +1,9 @@
+---
+tags:
+    - Original
+    - 'Author: jakobkogler'
+---
+
 # Primality tests
 
 This article describes multiple algorithms to determine if a number is prime or not.

--- a/src/algebra/prime-sieve-linear.md
+++ b/src/algebra/prime-sieve-linear.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: prime_sieve_linear
 ---
 
 # Linear Sieve

--- a/src/algebra/prime-sieve-linear.md
+++ b/src/algebra/prime-sieve-linear.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Linear Sieve
 
 Given a number $n$, find all prime numbers in a segment $[2;n]$.

--- a/src/algebra/primitive-root.md
+++ b/src/algebra/primitive-root.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Primitive Root
 
 ## Definition

--- a/src/algebra/primitive-root.md
+++ b/src/algebra/primitive-root.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: primitive_root
 ---
 
 # Primitive Root

--- a/src/algebra/sieve-of-eratosthenes.md
+++ b/src/algebra/sieve-of-eratosthenes.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-  - "From: e-maxx.ru"
+e_maxx_link: sieve_of_erathosthenes
 ---
 
 # Sieve of Eratosthenes

--- a/src/algebra/sieve-of-eratosthenes.md
+++ b/src/algebra/sieve-of-eratosthenes.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+  - "From: e-maxx.ru"
+---
+
 # Sieve of Eratosthenes
 
 Sieve of Eratosthenes is an algorithm for finding all the prime numbers in a segment $[1;n]$ using $O(n \log \log n)$ operations.

--- a/src/algebra/sieve-of-eratosthenes.md
+++ b/src/algebra/sieve-of-eratosthenes.md
@@ -1,7 +1,7 @@
 ---
 tags:
   - Translated
-e_maxx_link: sieve_of_erathosthenes
+e_maxx_link: eratosthenes_sieve
 ---
 
 # Sieve of Eratosthenes

--- a/src/combinatorics/binomial-coefficients.md
+++ b/src/combinatorics/binomial-coefficients.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: binomial_coeff
+---
+
 # Binomial Coefficients
 
 Binomial coefficients $\binom n k$ are the number of ways to select a set of $k$ elements from $n$ different elements without taking into account the order of arrangement of these elements (i.e., the number of unordered sets).

--- a/src/combinatorics/bishops-on-chessboard.md
+++ b/src/combinatorics/bishops-on-chessboard.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: bishops_arrangement
+---
+
 # Placing Bishops on a Chessboard
 
 Find the number of ways to place $K$ bishops on an $N \times N$ chessboard so that no two bishops attack each other.

--- a/src/combinatorics/bracket_sequences.md
+++ b/src/combinatorics/bracket_sequences.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: bracket_sequences
+---
+
 # Balanced bracket sequences
 
 A **balanced bracket sequence** is a string consisting of only brackets, such that this sequence, when inserted certain numbers and mathematical operations, gives a valid mathematical expression.

--- a/src/combinatorics/burnside.md
+++ b/src/combinatorics/burnside.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: burnside_polya
+---
+
 # Burnside's lemma / Pólya enumeration theorem
 
 ## Burnside's lemma

--- a/src/combinatorics/catalan-numbers.md
+++ b/src/combinatorics/catalan-numbers.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: catalan_numbers
+---
+
 # Catalan Numbers
 Catalan numbers is a number sequence, which is found useful in a number of combinatorial problems, often involving recursively-defined objects.
 

--- a/src/combinatorics/counting_labeled_graphs.md
+++ b/src/combinatorics/counting_labeled_graphs.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: counting_connected_graphs
+---
+
 # Counting labeled graphs
 
 ## Labeled graphs

--- a/src/combinatorics/generating_combinations.md
+++ b/src/combinatorics/generating_combinations.md
@@ -1,5 +1,8 @@
 ---
 title: Generating all K-combinations
+tags:
+  - Translated
+e_maxx_link: generating_combinations
 ---
 # Generating all $K$-combinations
 

--- a/src/combinatorics/inclusion-exclusion.md
+++ b/src/combinatorics/inclusion-exclusion.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: inclusion_exclusion_principle
+---
+
 # The Inclusion-Exclusion Principle
 
 The inclusion-exclusion principle is an important combinatorial way to compute the size of a set or the probability of complex events. It relates the sizes of individual sets with their union.

--- a/src/combinatorics/stars_and_bars.md
+++ b/src/combinatorics/stars_and_bars.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Stars and bars
 
 Stars and bars is a mathematical technique for solving certain combinatorial problems.

--- a/src/data_structures/deleting_in_log_n.md
+++ b/src/data_structures/deleting_in_log_n.md
@@ -1,5 +1,7 @@
 ---
-title: Deleting from a data structure in O(T(n)log n)
+title: Deleting from a data structure in O(T(n) log n)
+tags:
+  - Original
 ---
 # Deleting from a data structure in $O(T(n)\log n)$
 

--- a/src/data_structures/disjoint_set_union.md
+++ b/src/data_structures/disjoint_set_union.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: dsu
+---
+
 # Disjoint Set Union
 
 This article discusses the data structure **Disjoint Set Union** or **DSU**.

--- a/src/data_structures/fenwick.md
+++ b/src/data_structures/fenwick.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: fenwick_tree
+---
+
 # Fenwick Tree
 
 Let, $f$ be some _reversible_ function and $A$ be an array of integers of length $N$.

--- a/src/data_structures/randomized_heap.md
+++ b/src/data_structures/randomized_heap.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: randomized_heap
+---
+
 # Randomized Heap
 
 A randomized heap is a heap that, through using randomization, allows to perform all operations in expected logarithmic time.

--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: segment_tree
+---
+
 # Segment Tree
 
 A Segment Tree is a data structure that allows answering range queries over an array effectively, while still being flexible enough to allow modifying the array. 

--- a/src/data_structures/sparse-table.md
+++ b/src/data_structures/sparse-table.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Sparse Table
 
 Sparse Table is a data structure, that allows answering range queries.

--- a/src/data_structures/sqrt-tree.md
+++ b/src/data_structures/sqrt-tree.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Sqrt Tree
 
 Given an array $a$ that contains $n$ elements and the operation $\circ$ that satisfies associative property: $(x \circ y) \circ z = x \circ (y \circ z)$ is true for any $x$, $y$, $z$.

--- a/src/data_structures/sqrt_decomposition.md
+++ b/src/data_structures/sqrt_decomposition.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: sqrt_decomposition
+---
+
 # Sqrt Decomposition
 
 Sqrt Decomposition is a method (or a data structure) that allows you to perform some common operations (finding sum of the elements of the sub-array, finding the minimal/maximal element, etc.) in $O(\sqrt n)$ operations, which is much faster than $O(n)$ for the trivial algorithm.

--- a/src/data_structures/stack_queue_modification.md
+++ b/src/data_structures/stack_queue_modification.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: stacks_for_minima
+---
+
 # Minimum stack / Minimum queue
 
 In this article we will consider three problems: 

--- a/src/data_structures/treap.md
+++ b/src/data_structures/treap.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: treap
+---
+
 # Treap (Cartesian tree)
 
 A treap is a data structure which combines binary tree and binary heap (hence the name: tree + heap $\Rightarrow$ Treap).

--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Divide and Conquer DP
 
 Divide and Conquer is a dynamic programming optimization.

--- a/src/dynamic_programming/knuth-optimization.md
+++ b/src/dynamic_programming/knuth-optimization.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Knuth's Optimization
 
 Knuth's optimization, also known as the Knuth-Yao Speedup, is a special case of dynamic programming on ranges, that can optimize the time complexity of solutions by a linear factor, from $O(n^3)$ for standard range DP to $O(n^2)$.

--- a/src/dynamic_programming/profile-dynamics.md
+++ b/src/dynamic_programming/profile-dynamics.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: profile_dynamics
+---
+
 # Dynamic Programming on Broken Profile. Problem "Parquet"
 
 Common problems solved using DP on broken profile include:

--- a/src/dynamic_programming/zero_matrix.md
+++ b/src/dynamic_programming/zero_matrix.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: maximum_zero_submatrix
+---
+
 # Finding the largest zero submatrix
 
 You are given a matrix with `n` rows and `m` columns. Find the largest submatrix consisting of only zeros (a submatrix is a rectangular area of the matrix).

--- a/src/game_theory/games_on_graphs.md
+++ b/src/game_theory/games_on_graphs.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: games_on_graphs
+---
+
 # Games on arbitrary graphs
 
 Let a game be played by two players on an arbitrary graph $G$.

--- a/src/game_theory/sprague-grundy-nim.md
+++ b/src/game_theory/sprague-grundy-nim.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: sprague_grundy
+---
+
 # Sprague-Grundy theorem. Nim
 
 ## Introduction

--- a/src/geometry/area-of-simple-polygon.md
+++ b/src/geometry/area-of-simple-polygon.md
@@ -1,5 +1,8 @@
 ---
-title: Finding area of simple polygon in O(N) 
+title: Finding area of simple polygon in O(N)
+tags:
+  - Translated
+e_maxx_link: polygon_area
 ---
 # Finding area of simple polygon in $O(N)$
 

--- a/src/geometry/basic-geometry.md
+++ b/src/geometry/basic-geometry.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Basic Geometry
 
 In this article we will consider basic operations on points in Euclidean space which maintains the foundation of the whole analytical geometry.

--- a/src/geometry/check-segments-intersection.md
+++ b/src/geometry/check-segments-intersection.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: segments_intersection_checking
+---
+
 # Check if two segments intersect
 
 You are given two segments $(a, b)$ and $(c, d)$.

--- a/src/geometry/circle-circle-intersection.md
+++ b/src/geometry/circle-circle-intersection.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: circles_intersection
+---
+
 # Circle-Circle Intersection
 
 You are given two circles on a 2D plane, each one described as coordinates of its center and its radius. Find the points of their intersection (possible cases: one or two points, no intersection or circles coincide).

--- a/src/geometry/circle-line-intersection.md
+++ b/src/geometry/circle-line-intersection.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: circle_line_intersection
+---
+
 # Circle-Line Intersection
 
 Given the coordinates of the center of a circle and its radius, and the equation of a line, you're required to find the points of intersection.

--- a/src/geometry/convex-hull.md
+++ b/src/geometry/convex-hull.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: convex_hull_graham
+---
+
 # Convex Hull construction
 
 In this article we will discuss the problem of constructing a convex hull from a set of points.

--- a/src/geometry/convex_hull_trick.md
+++ b/src/geometry/convex_hull_trick.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Convex hull trick and Li Chao tree
 
 Consider the following problem. There are $n$ cities. You want to travel from city $1$ to city $n$ by car. To do this you have to buy some gasoline. It is known that a liter of gasoline costs $cost_k$ in the $k^{th}$ city. Initially your fuel tank is empty and you spend one liter of gasoline per kilometer. Cities are located on the same line in ascending order with $k^{th}$ city having coordinate $x_k$. Also you have to pay $toll_k$ to enter $k^{th}$ city. Your task is to make the trip with minimum possible cost. It's obvious that the solution can be calculated via dynamic programming:

--- a/src/geometry/delaunay.md
+++ b/src/geometry/delaunay.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: voronoi_diagram_2d_n4
+---
+
 # Delaunay triangulation and Voronoi diagram
 
 Consider a set $\{p_i\}$ of points on the plane.

--- a/src/geometry/halfplane-intersection.md
+++ b/src/geometry/halfplane-intersection.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Half-plane intersection
 
 In this article we will discuss the problem of computing the intersection of a set of half-planes. Such an intersection can be conveniently represented as a convex region/polygon, where every point inside of it is also inside all of the half-planes, and it is this polygon that we're trying to find or construct. We give some initial intuition for the problem, describe a $O(N \log N)$ approach known as the Sort-and-Incremental algorithm and give some sample applications of this technique.

--- a/src/geometry/intersecting_segments.md
+++ b/src/geometry/intersecting_segments.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: intersecting_segments
+---
+
 # Search for a pair of intersecting segments
 
 Given $n$ line segments on the plane. It is required to check whether at least two of them intersect with each other.

--- a/src/geometry/lattice-points.md
+++ b/src/geometry/lattice-points.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Lattice points inside non-lattice polygon
 
 For lattice polygons there is Pick's formula to enumerate the lattice points inside the polygon.

--- a/src/geometry/length-of-segments-union.md
+++ b/src/geometry/length-of-segments-union.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: length_of_segments_union
+---
+
 # Length of the union of segments
 
 Given $n$ segments on a line, each described by a pair of coordinates $(a_{i1}, a_{i2})$.

--- a/src/geometry/lines-intersection.md
+++ b/src/geometry/lines-intersection.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: lines_intersection
+---
+
 # Intersection Point of Lines
 
 You are given two lines, described via the equations $a_1 x + b_1 y + c_1 = 0$ and  $a_2 x + b_2 y + c_2 = 0$.

--- a/src/geometry/minkowski.md
+++ b/src/geometry/minkowski.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Minkowski sum of convex polygons
 
 ## Definition

--- a/src/geometry/nearest_points.md
+++ b/src/geometry/nearest_points.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: nearest_points
+---
+
 # Finding the nearest pair of points
 
 ## Problem statement

--- a/src/geometry/oriented-triangle-area.md
+++ b/src/geometry/oriented-triangle-area.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: oriented_area
+---
+
 # Oriented area of a triangle
 
 Given three points $p_1$, $p_2$ and $p_3$, calculate an oriented (signed) area of a triangle formed by them. The sign of the area is determined in the following way: imagine you are standing in the plane at point $p_1$ and are facing $p_2$. You go to $p_2$ and if $p_3$ is to your right (then we say the three vectors turn "clockwise"), the sign of the area is negative, otherwise it is positive. If the three points are collinear, the area is zero.

--- a/src/geometry/picks-theorem.md
+++ b/src/geometry/picks-theorem.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: pick_grid_theorem
+---
+
 # Pick's Theorem
 
 A polygon without self-intersections is called lattice if all its vertices have integer coordinates in some 2D grid. Pick's theorem provides a way to compute the area of this polygon through the number of vertices that are lying on the boundary and the number of vertices that lie strictly inside the polygon.

--- a/src/geometry/point-in-convex-polygon.md
+++ b/src/geometry/point-in-convex-polygon.md
@@ -1,5 +1,8 @@
 ---
 title: Check if point belongs to the convex polygon in O(log N)
+tags:
+  - Translated
+e_maxx_link: pt_in_polygon
 ---
 # Check if point belongs to the convex polygon in $O(\log N)$
 

--- a/src/geometry/point-location.md
+++ b/src/geometry/point-location.md
@@ -1,5 +1,7 @@
 ---
-title: Point location in O(log n) 
+title: Point location in O(log n)
+tags:
+  - Original
 ---
 # Point location in $O(log n)$
 

--- a/src/geometry/segment-to-line.md
+++ b/src/geometry/segment-to-line.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: segment_to_line
+---
+
 # Finding the equation of a line for a segment
 
 The task is: given the coordinates of the ends of a segment, construct a line passing through it.

--- a/src/geometry/segments-intersection.md
+++ b/src/geometry/segments-intersection.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: segments_intersection
+---
+
 # Finding intersection of two segments
 
 You are given two segments AB and CD, described as pairs of their endpoints. Each segment can be a single point if its endpoints are the same. 

--- a/src/geometry/tangents-to-two-circles.md
+++ b/src/geometry/tangents-to-two-circles.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: circle_tangents
+---
+
 # Finding common tangents to two circles
 
 Given two circles. It is required to find all their common tangents, i.e. all such lines that touch both circles simultaneously.

--- a/src/geometry/vertical_decomposition.md
+++ b/src/geometry/vertical_decomposition.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: triangles_union
+---
+
 # Vertical decomposition
 
 ## Overview

--- a/src/graph/01_bfs.md
+++ b/src/graph/01_bfs.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # 0-1 BFS
 
 It is well-known, that you can find the shortest paths between a single source and all other vertices in $O(|E|)$ using [Breadth First Search](breadth-first-search.md) in an **unweighted graph**, i.e. the distance is the minimal number of edges that you need to traverse from the source to another vertex.

--- a/src/graph/2SAT.md
+++ b/src/graph/2SAT.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: 2_sat
+---
+
 # 2-SAT 
 
 SAT (Boolean satisfiability problem) is the problem of assigning Boolean values to variables to satisfy a given Boolean formula.

--- a/src/graph/Assignment-problem-min-flow.md
+++ b/src/graph/Assignment-problem-min-flow.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: assignment_mincostflow
+---
+
 # Solving assignment problem using min-cost-flow
 
 The **assignment problem** has two equivalent statements:

--- a/src/graph/all-pair-shortest-path-floyd-warshall.md
+++ b/src/graph/all-pair-shortest-path-floyd-warshall.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: floyd_warshall_algorithm
+---
+
 # Floyd-Warshall Algorithm
 
 Given a directed or an undirected weighted graph $G$ with $n$ vertices.

--- a/src/graph/bellman_ford.md
+++ b/src/graph/bellman_ford.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: ford_bellman
+---
+
 # Bellman-Ford Algorithm
 
 **Single source shortest path with negative weight edges**

--- a/src/graph/bipartite-check.md
+++ b/src/graph/bipartite-check.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: bipartite_checking
+---
+
 # Check whether a graph is bipartite
 
 A bipartite graph is a graph whose vertices can be divided into two disjoint sets so that every edge connects two vertices from different sets (i.e. there are no edges which connect vertices from the same set). These sets are usually called sides.

--- a/src/graph/breadth-first-search.md
+++ b/src/graph/breadth-first-search.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: bfs
+---
+
 # Breadth-first search
 
 Breadth first search is one of the basic and essential searching algorithms on graphs.

--- a/src/graph/bridge-searching-online.md
+++ b/src/graph/bridge-searching-online.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: bridge_searching_online
+---
+
 # Finding Bridges Online
 
 We are given an undirected graph.

--- a/src/graph/bridge-searching.md
+++ b/src/graph/bridge-searching.md
@@ -1,5 +1,8 @@
 ---
-title: Finding bridges in a graph in O(N+M) 
+title: Finding bridges in a graph in O(N+M)
+tags:
+  - Translated
+e_maxx_link: bridge_searching
 ---
 # Finding bridges in a graph in $O(N+M)$
 

--- a/src/graph/cutpoints.md
+++ b/src/graph/cutpoints.md
@@ -1,5 +1,8 @@
 ---
-title: Finding articulation points in a graph in O(N+M) 
+title: Finding articulation points in a graph in O(N+M)
+tags:
+  - Translated
+e_maxx_link: cutpoints
 ---
 # Finding articulation points in a graph in $O(N+M)$
 

--- a/src/graph/depth-first-search.md
+++ b/src/graph/depth-first-search.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: dfs
+---
+
 # Depth First Search
 
 Depth First Search is one of the main graph algorithms.

--- a/src/graph/desopo_pape.md
+++ b/src/graph/desopo_pape.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: levit_algorithm
+---
+
 # D´Esopo-Pape algorithm
 
 Given a graph with $n$ vertices and $m$ edges with weights $w_i$ and a starting vertex $v_0$.

--- a/src/graph/dijkstra.md
+++ b/src/graph/dijkstra.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: dijkstra
+---
+
 # Dijkstra Algorithm
 
 You are given a directed or undirected weighted graph with $n$ vertices and $m$ edges. The weights of all edges are non-negative. You are also given a starting vertex $s$. This article discusses finding the lengths of the shortest paths from a starting vertex $s$ to all other vertices, and output the shortest paths themselves.

--- a/src/graph/dijkstra_sparse.md
+++ b/src/graph/dijkstra_sparse.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: dijkstra_sparse
+---
+
 # Dijkstra on sparse graphs
 
 For the statement of the problem, the algorithm with implementation and proof can be found on the article [Dijkstra's algorithm](dijkstra.md).

--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: dinic
+---
+
 # Maximum flow - Dinic's algorithm
 
 Dinic's algorithm solves the maximum flow problem in $O(V^2E)$. The maximum flow problem is defined in this article [Maximum flow - Ford-Fulkerson and Edmonds-Karp](edmonds_karp.md). This algorithm was discovered by Yefim Dinitz in 1970.

--- a/src/graph/edge_vertex_connectivity.md
+++ b/src/graph/edge_vertex_connectivity.md
@@ -1,3 +1,11 @@
+---
+tags:
+  - Translated
+e_maxx_link:
+  - rib_connectivity
+  - vertex_connectivity
+---
+
 # Edge connectivity / Vertex connectivity
 
 ## Definition

--- a/src/graph/edmonds_karp.md
+++ b/src/graph/edmonds_karp.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: edmonds_karp
+---
+
 # Maximum flow - Ford-Fulkerson and Edmonds-Karp
 
 The Edmonds-Karp algorithm is an implementation of the Ford-Fulkerson method for computing a maximal flow in a flow network.

--- a/src/graph/euler_path.md
+++ b/src/graph/euler_path.md
@@ -1,5 +1,8 @@
 ---
-title: Finding the Eulerian path in O(M)     
+title: Finding the Eulerian path in O(M)
+tags:
+  - Translated
+e_maxx_link: euler_path
 ---
 # Finding the Eulerian path in $O(M)$
 

--- a/src/graph/finding-cycle.md
+++ b/src/graph/finding-cycle.md
@@ -1,5 +1,8 @@
 ---
-title: Checking a graph for acyclicity and finding a cycle in O(M) 
+title: Checking a graph for acyclicity and finding a cycle in O(M)
+tags:
+  - Translated
+e_maxx_link: finding_cycle
 ---
 # Checking a graph for acyclicity and finding a cycle in $O(M)$
 

--- a/src/graph/finding-negative-cycle-in-graph.md
+++ b/src/graph/finding-negative-cycle-in-graph.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: negative_cycle
+---
+
 # Finding a negative cycle in the graph
 
 You are given a directed weighted graph $G$ with $N$ vertices and $M$ edges. Find any cycle of negative weight in it, if such a cycle exists.

--- a/src/graph/fixed_length_paths.md
+++ b/src/graph/fixed_length_paths.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: fixed_length_paths
+---
+
 # Number of paths of fixed length / Shortest paths of fixed length
 
 The following article describes solutions to these two problems built on the same idea:

--- a/src/graph/flow_with_demands.md
+++ b/src/graph/flow_with_demands.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: flow_with_limits
+---
+
 # Flows with demands
 
 In a normal flow network the flow of an edge is only limited by the capacity $c(e)$ from above and by 0 from below.

--- a/src/graph/hld.md
+++ b/src/graph/hld.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: heavy_light
+---
+
 # Heavy-light decomposition
 
 **Heavy-light decomposition** is a fairly general technique that allows us to effectively solve many problems that come down to **queries on a tree** .

--- a/src/graph/kirchhoff-theorem.md
+++ b/src/graph/kirchhoff-theorem.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: kirchhoff_theorem
+---
+
 # Kirchhoff's theorem. Finding the number of spanning trees
 
 Problem: You are given a connected undirected graph (with possible multiple edges) represented using an adjacency matrix. Find the number of different spanning trees of this graph.

--- a/src/graph/kuhn_maximum_bipartite_matching.md
+++ b/src/graph/kuhn_maximum_bipartite_matching.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: kuhn_matching
+---
+
 # Kuhn's Algorithm for Maximum Bipartite Matching
 
 ## Problem

--- a/src/graph/lca.md
+++ b/src/graph/lca.md
@@ -1,5 +1,8 @@
 ---
 title: Lowest Common Ancestor - O(sqrt(N)) and O(log N) with O(N) preprocessing
+tags:
+  - Translated
+e_maxx_link: lca
 ---
 # Lowest Common Ancestor - $O(\sqrt{N})$ and $O(\log N)$ with $O(N)$ preprocessing
 

--- a/src/graph/lca_binary_lifting.md
+++ b/src/graph/lca_binary_lifting.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: lca_simpler
+---
+
 # Lowest Common Ancestor - Binary Lifting
 
 Let $G$ be a tree.

--- a/src/graph/lca_farachcoltonbender.md
+++ b/src/graph/lca_farachcoltonbender.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: lca_linear
+---
+
 # Lowest Common Ancestor - Farach-Colton and Bender Algorithm
 
 Let $G$ be a tree.

--- a/src/graph/lca_tarjan.md
+++ b/src/graph/lca_tarjan.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: lca_linear_offline
+---
+
 # Lowest Common Ancestor - Tarjan's off-line algorithm
 
 We have a tree $G$ with $n$ nodes and we have $m$ queries of the form $(u, v)$.

--- a/src/graph/min_cost_flow.md
+++ b/src/graph/min_cost_flow.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: min_cost_flow
+---
+
 # Minimum-cost flow - Successive shortest path algorithm
 
 Given a network $G$ consisting of $n$ vertices and $m$ edges.

--- a/src/graph/mpm.md
+++ b/src/graph/mpm.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Maximum flow - MPM algorithm
 
 MPM (Malhotra, Pramodh-Kumar and Maheshwari) algorithm solves the maximum flow problem in $O(V^3)$. This algorithm is similar to [Dinic's algorithm](dinic.md).

--- a/src/graph/mst_kruskal.md
+++ b/src/graph/mst_kruskal.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: mst_kruskal
+---
+
 # Minimum spanning tree - Kruskal's algorithm
 
 Given a weighted undirected graph.

--- a/src/graph/mst_kruskal_with_dsu.md
+++ b/src/graph/mst_kruskal_with_dsu.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: mst_kruskal_with_dsu
+---
+
 # Minimum spanning tree - Kruskal with Disjoint Set Union
 
 For an explanation of the MST problem and the Kruskal algorithm, first see the [main article on Kruskal's algorithm](mst_kruskal.md).

--- a/src/graph/mst_prim.md
+++ b/src/graph/mst_prim.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: mst_prim
+---
+
 # Minimum spanning tree - Prim's algorithm
 
 Given a weighted, undirected graph $G$ with $n$ vertices and $m$ edges.

--- a/src/graph/pruefer_code.md
+++ b/src/graph/pruefer_code.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: prufer_code_cayley_formula
+---
+
 # Prüfer code
 
 In this article we will look at the so-called **Prüfer code** (or Prüfer sequence), which is a way of encoding a labeled tree into a sequence of numbers in a unique way.

--- a/src/graph/push-relabel-faster.md
+++ b/src/graph/push-relabel-faster.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: preflow_push_faster
+---
+
 # Maximum flow - Push-relabel method improved
 
 We will modify the [push-relabel method](push-relabel.md) to achieve a better runtime.

--- a/src/graph/push-relabel.md
+++ b/src/graph/push-relabel.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: preflow_push
+---
+
 # Maximum flow - Push-relabel algorithm
 
 The push-relabel algorithm (or also known as preflow-push algorithm) is an algorithm for computing the maximum flow of a flow network.

--- a/src/graph/rmq_linear.md
+++ b/src/graph/rmq_linear.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: rmq_linear
+---
+
 # Solve RMQ (Range Minimum Query) by finding LCA (Lowest Common Ancestor)
 
 Given an array `A[0..N-1]`.

--- a/src/graph/search-for-connected-components.md
+++ b/src/graph/search-for-connected-components.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: connected_components
+---
+
 # Search for connected components in a graph
 
 Given an undirected graph $G$ with $n$ nodes and $m$ edges. We are required to find in it all the connected components, i.e, several groups of vertices such that within a group each vertex can be reached from another and no path exists between different groups.

--- a/src/graph/second_best_mst.md
+++ b/src/graph/second_best_mst.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Second Best Minimum Spanning Tree
 
 A Minimum Spanning Tree $T$ is a tree for the given graph $G$ which spans over all vertices of the given graph and has the minimum weight sum of all the edges, from all the possible spanning trees.

--- a/src/graph/strong-orientation.md
+++ b/src/graph/strong-orientation.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - Original
+---
+
 # Strong Orientation
 
 A **strong orientation** of an undirected graph is an assignment of a direction to each edge that makes it a [strongly connected graph](strongly-connected-components.md).

--- a/src/graph/strongly-connected-components.md
+++ b/src/graph/strongly-connected-components.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: strong_connected_components
+---
+
 # Finding strongly connected components / Building condensation graph
 
 ## Definitions

--- a/src/graph/topological-sort.md
+++ b/src/graph/topological-sort.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: topological_sort
+---
+
 # Topological Sorting
 
 You are given a directed graph with $n$ vertices and $m$ edges. You have to **number the vertices** so that every edge leads from the vertex with a smaller number assigned to the vertex with a larger one.

--- a/src/graph/tree_painting.md
+++ b/src/graph/tree_painting.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: tree_painting
+---
+
 # Paint the edges of the tree
 
 This is a fairly common task. Given a tree $G$ with $N$ vertices. There are two types of queries: the first one is to paint an edge, the second one is to query the number of colored edges between two vertices.

--- a/src/linear_algebra/determinant-gauss.md
+++ b/src/linear_algebra/determinant-gauss.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: determinant_gauss
+---
+
 # Calculating the determinant of a matrix by Gauss
 
 Problem: Given a matrix $A$ of size $N \times N$. Compute its determinant.

--- a/src/linear_algebra/determinant-kraut.md
+++ b/src/linear_algebra/determinant-kraut.md
@@ -1,5 +1,7 @@
 ---
 title: Calculating the determinant using Kraut method
+tags:
+  - Original
 ---
 # Calculating the determinant using Kraut method in $O(N^3)$
 

--- a/src/linear_algebra/linear-system-gauss.md
+++ b/src/linear_algebra/linear-system-gauss.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: linear_systems_gauss
+---
+
 # Gauss method for solving system of linear equations
 
 Given a system of $n$ linear algebraic equations (SLAE) with $m$ unknowns. You are asked to solve the system: to determine if it has no solution, exactly one solution or infinite number of solutions. And in case it has at least one solution, find any of them.

--- a/src/linear_algebra/rank-matrix.md
+++ b/src/linear_algebra/rank-matrix.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: matrix_rank
+---
+
 # Finding the rank of a matrix
 
 **The rank of a matrix** is the largest number of linearly independent rows/columns of the matrix. The rank is not only defined  for square matrices.

--- a/src/navigation.md
+++ b/src/navigation.md
@@ -51,7 +51,7 @@
         - [Sqrt Tree](data_structures/sqrt-tree.md)
         - [Randomized Heap](data_structures/randomized_heap.md)
     - Advanced
-        - [Deleting from a data structure in O(T(n)log n)](data_structures/deleting_in_log_n.md)
+        - [Deleting from a data structure in O(T(n) log n)](data_structures/deleting_in_log_n.md)
 - Dynamic Programming
     - DP optimizations
         - [Divide and Conquer DP](dynamic_programming/divide-and-conquer-dp.md)
@@ -90,7 +90,7 @@
         - [The Inclusion-Exclusion Principle](combinatorics/inclusion-exclusion.md)
         - [Burnside's lemma / Pólya enumeration theorem](combinatorics/burnside.md)
         - [Stars and bars](combinatorics/stars_and_bars.md)
-        - [Generating all $K$-combinations](combinatorics/generating_combinations.md)
+        - [Generating all K-combinations](combinatorics/generating_combinations.md)
     - Tasks
         - [Placing Bishops on a Chessboard](combinatorics/bishops-on-chessboard.md)
         - [Balanced bracket sequences](combinatorics/bracket_sequences.md)
@@ -129,7 +129,7 @@
         - [Finding the nearest pair of points](geometry/nearest_points.md)
         - [Delaunay triangulation and Voronoi diagram](geometry/delaunay.md)
         - [Vertical decomposition](geometry/vertical_decomposition.md)
-        - [Half-plane intersection - S&I Algorithm in O(Nlog N)](geometry/halfplane-intersection.md)
+        - [Half-plane intersection - S&I Algorithm in O(N log N)](geometry/halfplane-intersection.md)
 - Graphs
     - Graph traversal
         - [Breadth First Search](graph/breadth-first-search.md)

--- a/src/navigation.md
+++ b/src/navigation.md
@@ -1,6 +1,7 @@
 - Home
     - [Main Page](index.md)
     - [Navigation](navigation.md)
+    - [Tag index](tags.md)
     - [How to Contribute](contrib.md)
     - [Preview](preview.md)
 - Algebra

--- a/src/navigation.md
+++ b/src/navigation.md
@@ -24,7 +24,7 @@
         - [Modular Inverse](algebra/module-inverse.md)
         - [Linear Congruence Equation](algebra/linear_congruence_equation.md)
         - [Chinese Remainder Theorem](algebra/chinese-remainder-theorem.md)
-        - [Factorial modulo $p$](algebra/factorial-modulo.md)
+        - [Factorial modulo p](algebra/factorial-modulo.md)
         - [Discrete Log](algebra/discrete-log.md)
         - [Primitive Root](algebra/primitive-root.md)
         - [Discrete Root](algebra/discrete-root.md)

--- a/src/num_methods/roots_newton.md
+++ b/src/num_methods/roots_newton.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: roots_newton
+---
+
 # Newton's method for finding roots 
 
 This is an iterative method invented by Isaac Newton around 1664. However, this method is also sometimes called the Raphson method, since Raphson invented the same algorithm a few years after Newton, but his article was published much earlier.

--- a/src/num_methods/simpson-integration.md
+++ b/src/num_methods/simpson-integration.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: simpson_integrating
+---
+
 # Integration by Simpson's formula
 
 We are going to calculate the value of a definite integral

--- a/src/num_methods/ternary_search.md
+++ b/src/num_methods/ternary_search.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: ternary_search
+---	
+
 # Ternary Search
 
 We are given a function $f(x)$ which is unimodal on an interval $[l, r]$. By unimodal function, we mean one of two behaviors of the function: 

--- a/src/others/15-puzzle.md
+++ b/src/others/15-puzzle.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: 15_puzzle
+---
+
 # 15 Puzzle Game: Existence Of The Solution
 
 This game is played on a $4 \times 4$ board. On this board there are $15$ playing tiles numbered from 1 to 15. One cell is left empty (denoted by 0). You need to get the board to the position presented below by repeatedly moving one of the tiles to the free space:

--- a/src/others/josephus_problem.md
+++ b/src/others/josephus_problem.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: joseph_problem
+---
+
 # Josephus Problem
 
 ## Statement

--- a/src/others/maximum_average_segment.md
+++ b/src/others/maximum_average_segment.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: maximum_average_segment
+---
+
 # Search the subarray with the maximum/minimum sum
 
 Here, we consider the problem of finding a subarray with maximum sum, as well as some of its variations (including the algorithm for solving this problem online).

--- a/src/others/stern_brocot_tree_farey_sequences.md
+++ b/src/others/stern_brocot_tree_farey_sequences.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: stern_brocot_farey
+---
+
 # The Stern-Brocot tree and Farey sequences
 
 ## Stern-Brocot tree

--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -55,15 +55,22 @@ Describe the issue of this article in detail.
 <ul class="metadata page-metadata" data-bi-name="page info" lang="en-us" dir="ltr">
   {{ lang.t("source.file.date.updated") }}:
   {{ page.meta.git_revision_date_localized }}
-</ul>
-
 <!-- Tags -->
 {% if page and page.meta and page.meta.e_maxx_link %}
 {{ tags.append({'name':'From: e-maxx.ru', 'url': 'https://e-maxx.ru/algo/' + page.meta.e_maxx_link}) or '' }}
 {% endif %}
 {% if "tags" in config.plugins %}
-  {% include "partials/tags.html" %}
+    {% for tag in tags %}
+      {% if tag.url %}
+        <a href="{{ tag.url | url }}" class="md-tag">
+          {{ tag.name }}
+        </a>
+      {% else %}
+        <span class="md-tag">{{ tag.name }}</span>
+      {% endif %}
+    {% endfor %}
 {% endif %}
+</ul>
 
 {% if not "\x3ch1" in page.content %}
   <h1>{{ page.title | d(config.site_name, true)}}</h1>

--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -58,6 +58,9 @@ Describe the issue of this article in detail.
 </ul>
 
 <!-- Tags -->
+{% if page and page.meta and page.meta.e_maxx_link %}
+{{ tags.append({'name':'From: e-maxx.ru', 'url': 'https://e-maxx.ru/algo/' + page.meta.e_maxx_link}) or '' }}
+{% endif %}
 {% if "tags" in config.plugins %}
   {% include "partials/tags.html" %}
 {% endif %}

--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -54,22 +54,20 @@ Describe the issue of this article in detail.
 <!-- Date of last commit -->
 <ul class="metadata page-metadata" data-bi-name="page info" lang="en-us" dir="ltr">
   {{ lang.t("source.file.date.updated") }}:
-  {{ page.meta.git_revision_date_localized }}
+  {{ page.meta.git_revision_date_localized }}&emsp;
 <!-- Tags -->
 {% if page and page.meta and page.meta.e_maxx_link %}
 {{ tags.append({'name':'From: e-maxx.ru', 'url': 'https://e-maxx.ru/algo/' + page.meta.e_maxx_link}) or '' }}
 {% endif %}
-{% if "tags" in config.plugins %}
-    {% for tag in tags %}
-      {% if tag.url %}
-        <a href="{{ tag.url | url }}" class="md-tag">
-          {{ tag.name }}
-        </a>
-      {% else %}
-        <span class="md-tag">{{ tag.name }}</span>
-      {% endif %}
-    {% endfor %}
-{% endif %}
+{% for tag in tags %}
+  {% if tag.url %}
+    <a href="{{ tag.url | url }}" class="md-tag">
+      {{ tag.name }}
+    </a>
+  {% else %}
+    <span class="md-tag">{{ tag.name }}</span>
+  {% endif %}
+{% endfor %}
 </ul>
 
 {% if not "\x3ch1" in page.content %}

--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -57,7 +57,11 @@ Describe the issue of this article in detail.
   {{ page.meta.git_revision_date_localized }}&emsp;
 <!-- Tags -->
 {% if page and page.meta and page.meta.e_maxx_link %}
-{{ tags.append({'name':'From: e-maxx.ru', 'url': 'https://e-maxx.ru/algo/' + page.meta.e_maxx_link}) or '' }}
+  {% set links = page.meta.e_maxx_link %}
+  {% set links = [links] if links is string else links %}
+  {% for link in links %}
+    {% do tags.append({'name':'From: e-maxx.ru', 'url': 'https://e-maxx.ru/algo/' + link}) %}
+  {% endfor %}
 {% endif %}
 {% for tag in tags %}
   {% if tag.url %}

--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -57,6 +57,11 @@ Describe the issue of this article in detail.
   {{ page.meta.git_revision_date_localized }}
 </ul>
 
+<!-- Tags -->
+{% if "tags" in config.plugins %}
+  {% include "partials/tags.html" %}
+{% endif %}
+
 {% if not "\x3ch1" in page.content %}
   <h1>{{ page.title | d(config.site_name, true)}}</h1>
 {% endif %}

--- a/src/schedules/schedule-with-completion-duration.md
+++ b/src/schedules/schedule-with-completion-duration.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: schedule_with_completion_duration
+---
+
 # Optimal schedule of jobs given their deadlines and durations
 
 Suppose, we have a set of jobs, and we are aware of every job’s deadline and its duration. The execution of a job cannot be interrupted prior to its ending. It is required to create such a schedule to accomplish the biggest number of jobs.

--- a/src/schedules/schedule_one_machine.md
+++ b/src/schedules/schedule_one_machine.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: johnson_problem_1
+---
+
 # Scheduling jobs on one machine
 
 This task is about finding an optimal schedule for $n$ jobs on a single machine, if the job $i$ can be processed in $t_i$ time, but for the $t$ seconds waiting before processing the job a penalty of $f_i(t)$ has to be paid.

--- a/src/schedules/schedule_two_machines.md
+++ b/src/schedules/schedule_two_machines.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: johnson_problem_2
+---
+
 # Scheduling jobs on two machines
 
 This task is about finding an optimal schedule for $n$ jobs on two machines.

--- a/src/sequences/k-th.md
+++ b/src/sequences/k-th.md
@@ -1,5 +1,8 @@
 ---
 title: K-th order statistic in O(N)
+tags:
+  - Translated
+e_maxx_link: kth_order_statistics
 ---
 # $K$th order statistic in $O(N)$
 

--- a/src/sequences/longest_increasing_subsequence.md
+++ b/src/sequences/longest_increasing_subsequence.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: longest_increasing_subseq_log
+---
+
 # Longest increasing subsequence
 
 We are given an array with $n$ numbers: $a[0 \dots n-1]$.

--- a/src/sequences/rmq.md
+++ b/src/sequences/rmq.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: rmq
+---
+
 # Range Minimum Query
 
 You are given an array $A[1..N]$.

--- a/src/string/aho_corasick.md
+++ b/src/string/aho_corasick.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: aho_corasick
+---
+
 # Aho-Corasick algorithm
 
 Let there be a set of strings with the total length $m$ (sum of all lengths).

--- a/src/string/expression_parsing.md
+++ b/src/string/expression_parsing.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: expressions_parsing
+---
+
 # Expression parsing
 
 A string containing a mathematical expression containing numbers and various operators is given.

--- a/src/string/lyndon_factorization.md
+++ b/src/string/lyndon_factorization.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: duval_algorithm
+---
+
 # Lyndon factorization
 
 ## Lyndon factorization

--- a/src/string/main_lorentz.md
+++ b/src/string/main_lorentz.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: string_tandems
+---
+
 # Finding repetitions
 
 Given a string $s$ of length $n$.

--- a/src/string/manacher.md
+++ b/src/string/manacher.md
@@ -1,5 +1,8 @@
 ---
 title: Manacher's Algorithm - Finding all sub-palindromes in O(N)
+tags:
+  - Translated
+e_maxx_link: palindromes_count
 ---
 # Manacher's Algorithm - Finding all sub-palindromes in $O(N)$
 

--- a/src/string/prefix-function.md
+++ b/src/string/prefix-function.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: prefix_function
+---
+
 # Prefix function. Knuth–Morris–Pratt algorithm
 
 ## Prefix function definition

--- a/src/string/rabin-karp.md
+++ b/src/string/rabin-karp.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: rabin_karp
+---
+
 # Rabin-Karp Algorithm for string matching
 
 This algorithm is based on the concept of hashing, so if you are not familiar with string hashing, refer to the [string hashing](string-hashing.md) article.

--- a/src/string/string-hashing.md
+++ b/src/string/string-hashing.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: string_hashes
+---
+
 # String Hashing
 
 Hashing algorithms are helpful in solving a lot of problems.

--- a/src/string/suffix-array.md
+++ b/src/string/suffix-array.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: suffix_array
+---
+
 # Suffix Array
 
 ## Definition

--- a/src/string/suffix-automaton.md
+++ b/src/string/suffix-automaton.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: suffix_automata
+---
+
 # Suffix Automaton
 
 A **suffix automaton** is a powerful data structure that allows solving many string-related problems. 

--- a/src/string/suffix-tree-ukkonen.md
+++ b/src/string/suffix-tree-ukkonen.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: ukkonen
+---
+
 # Suffix Tree. Ukkonen's Algorithm
 
 *This article is a stub and doesn't contain any descriptions. For a description of the algorithm, refer to other sources, such as [Algorithms on Strings, Trees, and Sequences](http://web.stanford.edu/~mjkay/gusfield.pdf) by Dan Gusfield.*

--- a/src/string/z-function.md
+++ b/src/string/z-function.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - Translated
+e_maxx_link: z_function
+---
+
 # Z-function and its calculation
 
 Suppose we are given a string $s$ of length $n$. The **Z-function** for this string is an array of length $n$ where the $i$-th element is equal to the greatest number of characters starting from the position $i$ that coincide with the first characters of $s$.

--- a/src/tags.md
+++ b/src/tags.md
@@ -1,0 +1,5 @@
+# Tags
+
+This file contains a global index of all tags used on the pages.
+
+[TAGS]


### PR DESCRIPTION
We have several issues for which, in my opinion, it would be useful to use tags feature:

- #234 
- #792

I believe that we can resolve both of them by enabling tags. Then each article will have a primary tag -- whether it is translated or original to the website. And then, additionally, it could have some extra tags to credit authors. My assumption would be that we would credit original article authors with "Author: X" tag and major contributors with "Contributor: X" tags.

I'm not sure whether we want to credit translators. If we do, we could use "Translator: X" tag as well.

@jakobkogler any thoughts on the change? For now I only added some tags to the algebra section. If we agree on the change, I will go through the rest of articles as well and and some info on the tags to contributor guide.