### PR TITLE
fix: latex rendering in ToC with data-toc-label

### DIFF
--- a/src/algebra/factorial-divisors.md
+++ b/src/algebra/factorial-divisors.md
@@ -8,7 +8,7 @@ e_maxx_link: factorial_divisors
 
 You are given two numbers $n$ and $k$. Find the largest power of $k$ $x$ such that $n!$ is divisible by $k^x$.
 
-## Prime $k$
+## Prime $k$ {data-toc-label="Prime k"}
 
 Let's first consider the case of prime $k$. The explicit expression for factorial
 
@@ -41,7 +41,7 @@ int fact_pow (int n, int k) {
 
 ```
 
-## Composite $k$
+## Composite $k$ {data-toc-label="Composite k"}
 
 The same idea can't be applied directly. Instead we can factor $k$, representing it as $k = k_1^{p_1} \cdot \ldots \cdot k_m^{p_m}$. For each $k_i$, we find the number of times it is present in $n!$ using the algorithm described above - let's call this value $a_i$. The answer for composite $k$ will be
 


### PR DESCRIPTION
![pr](https://user-images.githubusercontent.com/82411321/179332943-a6921fb2-cd13-4ede-8020-9a1be8bf188b.png)

As discussed in #886, using `data-toc-label` will still render latex on the main page but it ignore in ToC.