### PR TITLE
Remove unnecessary reversal in finding-cycle algo

### DIFF
--- a/src/graph/finding-cycle.md
+++ b/src/graph/finding-cycle.md
@@ -119,7 +119,6 @@ void find_cycle() {
         for (int v = cycle_end; v != cycle_start; v = parent[v])
             cycle.push_back(v);
         cycle.push_back(cycle_start);
-        reverse(cycle.begin(), cycle.end());
 
         cout << "Cycle found: ";
         for (int v : cycle)


### PR DESCRIPTION
When finding a cycle in an undirected graph, one doesn't have to reverse the cycle before printing it.