### PR TITLE
Change applyPermutation method

### DIFF
--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -137,7 +137,7 @@ Therefore, we can raise this transformation matrix to the $n$-th power to find $
 vector<int> applyPermutation(vector<int> sequence, vector<int> permutation) {
     vector<int> newSequence(sequence.size());
     for(int i = 0; i < sequence.size(); i++) {
-        newSequence[permutation[i]] = sequence[i];
+        newSequence[i] = sequence[permutation[i]];
     }
     return newSequence;
 }


### PR DESCRIPTION
Previously newSequence[permutation[i]] = sequence[i]; doesn't work Correct way to do it is newSequence[i] = sequence[permutation[i]]; which works as intented