### PR TITLE
Fix typo in intermediate value theorem

### DIFF
--- a/src/num_methods/binary_search.md
+++ b/src/num_methods/binary_search.md
@@ -122,7 +122,7 @@ so now we need to check whether there is a subarray of a new array $a_i - \lambd
 
 Let $f : \mathbb R \to \mathbb R$ be a real-valued function that is continuous on a segment $[L, R]$.
 
-Without loss of generality assume that $f(L) \leq f(R)$. From [intermediate value theorem](https://en.wikipedia.org/wiki/Intermediate_value_theorem) it follows that for any $y \in [f(L), f(R)]$ there is $x \in [L, R]$ such that $f(y) = x$. Note that, unlike previous paragraphs, the function is _not_ required to be monotonous.
+Without loss of generality assume that $f(L) \leq f(R)$. From [intermediate value theorem](https://en.wikipedia.org/wiki/Intermediate_value_theorem) it follows that for any $y \in [f(L), f(R)]$ there is $x \in [L, R]$ such that $f(x) = y$. Note that, unlike previous paragraphs, the function is _not_ required to be monotonous.
 
 The value $x$ could be approximated up to $\pm\delta$ in $O\left(\log \frac{R-L}{\delta}\right)$ time for any specific value of $\delta$. The idea is essentially the same, if we take $M \in (L, R)$ then we would be able to reduce the search interval to either $[L, M]$ or $[M, R]$ depending on whether $f(M)$ is larger than $y$. One common example here would be finding roots of odd-degree polynomials.
 


### PR DESCRIPTION
Change `f(y) = x` to `f(x) = y` 